### PR TITLE
Added test to show weird behaviour with small output buffers.

### DIFF
--- a/tests/test_small_output.c
+++ b/tests/test_small_output.c
@@ -1,0 +1,68 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <librsync.h>
+
+// Test behaviour when the output buffer is too small, and grows bit by bit
+// Parameters: test_small_output.test  INPUTSIZE  INITIAL_BUFFER_SIZE  OUTPUT_GROWTH_RATE
+
+int main(int argc, const char** argv)
+{
+   int i;
+   size_t input_size = atoi(argv[1]);
+   size_t start = atoi(argv[2]);
+   size_t step = atoi(argv[3]);
+
+   printf("Input size: %d\n", input_size);
+   printf("Output buffer start at %d step growth of %d\n", start, step);
+
+   // make this silly-huge, we don't want to test part
+   char * outbuf = (char*)malloc(1024+10*input_size);
+
+   // load with anything
+   char * in = (char*)malloc(input_size);
+   for (i = 0; i < input_size; ++i)
+      in[i] = 'x';
+
+   // generate a signature
+   rs_buffers_t buf;
+   buf.next_out = outbuf;
+   buf.avail_out = start;
+   buf.next_in = (char*)(in);   // TODO why is this not const void* ?
+   buf.avail_in = input_size;
+   buf.eof_in = 0;
+
+   rs_job_t * job = rs_sig_begin(RS_DEFAULT_BLOCK_LEN, 0, RS_BLAKE2_SIG_MAGIC);
+
+   while (buf.avail_in > 0)
+   {
+      rs_result r = rs_job_iter(job, &buf);
+      if (r != RS_BLOCKED)
+      {
+         printf("FAIL, expected 'blocked'\n");
+         return 1;
+      }
+      // if there is data remaining, then rsync needs more output
+      // give it a little each time...
+      if (buf.avail_in > 0)
+         buf.avail_out += step;
+   }
+
+   // all the input has been consumed.
+   // run the job once more, with no data, and the EOF flag set.
+   // we should see "DONE" now.
+   buf.eof_in = 1;
+   rs_result r = rs_job_iter(job, &buf);
+   if (r != RS_DONE)
+   {
+      printf("FAIL, expected 'done'\n");
+      return 1;
+   }
+
+   rs_job_free(job);
+
+   printf("Final signature size: %d\n", (buf.next_out - outbuf));
+
+   return 0;
+}

--- a/tests/test_small_output.run
+++ b/tests/test_small_output.run
@@ -1,0 +1,39 @@
+#! /bin/sh
+
+gcc -o test_small_output.test test_small_output.c -I.. -L../.libs/ -lrsync
+
+echo TestSmallOutput_1_1_30 ; ./test_small_output.test 1 1 30
+echo
+echo TestSmallOutput_1_1_1 ; ./test_small_output.test 1 1 1
+echo
+echo TestSmallOutput_20000_1_30 ; ./test_small_output.test 20000 1 30
+echo
+echo TestSmallOutput_20000_1_1 ; ./test_small_output.test 20000 1 1
+echo
+
+echo TestSmallOutput_0_20_0 ; ./test_small_output.test 0 20 0
+echo
+echo TestSmallOutput_0_10_30 ; ./test_small_output.test 0 10 30
+echo
+echo TestSmallOutput_0_0_30 ; ./test_small_output.test 0 0 30
+echo
+echo TestSmallOutput_0_1_1 ; ./test_small_output.test 0 1 1
+echo
+
+echo TestSmallOutput_20000_1000_30 ; ./test_small_output.test 20000 1000 30
+echo
+echo TestSmallOutput_20000_1000_1 ; ./test_small_output.test 20000 1000 1
+echo
+
+echo TestSmallOutput_2000000_16000_16000 ; ./test_small_output.test 2000000 16000 16000
+echo
+echo TestSmallOutput_2000000_16000_30 ; ./test_small_output.test 2000000 16000 30
+echo TestSmallOutput_2000000_1000_30 ; ./test_small_output.test 2000000 1000 30
+echo
+echo TestSmallOutput_2000000_1000_1 ; ./test_small_output.test 2000000 1000 1
+echo
+
+echo TestSmallOutput_1_1000_30 ; ./test_small_output.test 1 1000 30
+echo
+echo TestSmallOutput_1_1000_1 ; ./test_small_output.test 1 1000 1
+echo


### PR DESCRIPTION
Backported from my CMake-based branch.

I see issues when the output buffer is too small.
librsync.h indicates I should increase the buffer size and reexecute, but that seems to be buggy.

Here is a test, the parameters control the input size, the initial output buffer size, and the output buffer growth rate (additive).

Its quite easy to allocate too-small a buffer, and as the input size goes up, it seems that the minimum required output buffer sizes also change.
