### PR TITLE
Build rdiff target optionally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: c
 
 before_script:
   - cmake --help
-  - cmake $CMAKE_GENERATOR .
+  - cmake $CMAKE_OPTIONS $CMAKE_GENERATOR .
   
 sudo: required
 
@@ -43,6 +43,11 @@ matrix:
       dist: trusty
       script:
         - ninja check doc
+
+    - dist: precise
+      sudo: false
+      env: CMAKE_OPTIONS="-D BUILD_RDIFF=OFF"
+
 
 # Docs are tested on Trusty with Ninja, and on OSX (which might have a more
 # recent Doxygen.)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,11 @@ if (NOT CMAKE_SYSTEM_NAME)
 	message(FATAL_ERROR "No target OS set")
 endif()
 
+# Add an option to exclude rdiff executable from build
+# This is useful, because it allows to remove POPT dependency if a user is interested only in the
+# rsync library itself and not in the rdiff executable
+option(BUILD_RDIFF "Whether to build rdiff executable or not" ON)
+
 include ( CheckIncludeFiles )
 check_include_files ( alloca.h HAVE_ALLOCA_H )
 check_include_files ( dlfcn.h HAVE_DLFCN_H )
@@ -123,18 +128,21 @@ message (STATUS "BUILD_HOSTNAME = ${BUILD_HOSTNAME}")
 message (STATUS "CMAKE_SYSTEM = ${CMAKE_SYSTEM}")
 
 # Find POPT
-find_package(POPT REQUIRED)
-if ( POPT_FOUND )
-  include_directories(${POPT_INCLUDE_DIRS})
-endif ( POPT_FOUND )
+if (BUILD_RDIFF)
+  find_package(POPT)
+  if (POPT_FOUND)
+    include_directories(${POPT_INCLUDE_DIRS})
+  endif (POPT_FOUND)
+endif (BUILD_RDIFF)
 
 # Find BZIP
-find_package (BZip2 REQUIRED)
+find_package (BZip2)
 if (BZIP2_FOUND)
   message (STATUS "Found components for BZIP2")
   message (STATUS "BZIP2_INCLUDE_DIR  = ${BZIP2_INCLUDE_DIR}")
   message (STATUS "BZIP2_LIBRARIES = ${BZIP2_LIBRARIES}")
   include_directories(${BZIP2_INCLUDE_DIR})
+  list(APPEND rsync_LIB_DEPS ${BZIP2_LIBRARIES})
 endif (BZIP2_FOUND)
 
 # Find Perl
@@ -144,12 +152,13 @@ if (PERL_FOUND)
 endif (PERL_FOUND)
 
 # Find ZLIB
-find_package (ZLIB REQUIRED)
+find_package (ZLIB)
 if (ZLIB_FOUND)
   message (STATUS "Found components for ZLIB")
   message (STATUS "ZLIB_INCLUDE_DIR  = ${ZLIB_INCLUDE_DIR}")
   message (STATUS "ZLIB_LIBRARIES = ${ZLIB_LIBRARIES}")
   include_directories(${ZLIB_INCLUDE_DIRS})
+  list(APPEND rsync_LIB_DEPS ${ZLIB_LIBRARIES})
 endif (ZLIB_FOUND)
 
 # Doxygen doc generator
@@ -191,8 +200,13 @@ add_test(NAME Changes COMMAND changes.test ${CMAKE_CURRENT_BINARY_DIR} WORKING_D
 # `make check` that will build everything and then run the tests.
 # See https://cmake.org/Wiki/CMakeEmulateMakeCheck and
 # https://github.com/librsync/librsync/issues/49
+if (BUILD_RDIFF)
+  set(LAST_TARGET rdiff)
+else (BUILD_RDIFF)
+  set(LAST_TARGET rsync)
+endif (BUILD_RDIFF)
 add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
-add_dependencies(check rdiff isprefix_test)
+add_dependencies(check ${LAST_TARGET} isprefix_test)
 
 
 enable_testing()
@@ -250,10 +264,7 @@ set(rsync_LIB_SRCS
 
 add_library(rsync SHARED ${rsync_LIB_SRCS})
 
-target_link_libraries(rsync
-   ${BZIP2_LIBRARIES}
-   ${ZLIB_LIBRARIES}
-)
+target_link_libraries(rsync ${rsync_LIB_DEPS})
 
 set_target_properties(rsync PROPERTIES VERSION ${LIBRSYNC_VERSION}
         SOVERSION ${LIBRSYNC_MAJOR_VERSION})
@@ -262,15 +273,17 @@ install(TARGETS rsync ${INSTALL_TARGETS_DEFAULT_ARGS} DESTINATION lib)
 
 ########### next target ###############
 
-set(rdiff_SRCS
-    src/rdiff.c
-    src/isprefix.c)
-
-add_executable(rdiff ${rdiff_SRCS})
-
-target_link_libraries(rdiff rsync ${POPT_LIBRARIES})
-
-install(TARGETS rdiff ${INSTALL_TARGETS_DEFAULT_ARGS} DESTINATION bin)
+if (BUILD_RDIFF)
+  set(rdiff_SRCS
+      src/rdiff.c
+      src/isprefix.c)
+  
+  add_executable(rdiff ${rdiff_SRCS})
+  
+  target_link_libraries(rdiff rsync ${POPT_LIBRARIES})
+  
+  install(TARGETS rdiff ${INSTALL_TARGETS_DEFAULT_ARGS} DESTINATION bin)
+endif (BUILD_RDIFF)
 
 
 ########### install files ###############

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,10 @@ endif()
 # Add an option to exclude rdiff executable from build
 # This is useful, because it allows to remove POPT dependency if a user is interested only in the
 # rsync library itself and not in the rdiff executable
-option(BUILD_RDIFF "Whether to build rdiff executable or not" ON)
+option(BUILD_RDIFF "Whether or not to build rdiff executable" ON)
+
+# Add an option to include compression support
+option(ENABLE_COMPRESSION "Whether or not to build with compression support" OFF)
 
 include ( CheckIncludeFiles )
 check_include_files ( alloca.h HAVE_ALLOCA_H )
@@ -65,6 +68,12 @@ check_include_files ( zlib.h HAVE_ZLIB_H )
 set ( STDC_HEADERS 1 )
 set ( DO_RS_TRACE 0 )
 set ( HAVE_PROGRAM_INVOCATION_NAME 0)
+
+# Remove compression support if not needed
+if (NOT ENABLE_COMPRESSION)
+  SET(HAVE_BZLIB_H 0)
+  SET(HAVE_ZLIB_H 0)
+endif (NOT ENABLE_COMPRESSION)
 
 
 include ( CheckFunctionExists )
@@ -128,12 +137,10 @@ message (STATUS "BUILD_HOSTNAME = ${BUILD_HOSTNAME}")
 message (STATUS "CMAKE_SYSTEM = ${CMAKE_SYSTEM}")
 
 # Find POPT
-if (BUILD_RDIFF)
-  find_package(POPT)
-  if (POPT_FOUND)
-    include_directories(${POPT_INCLUDE_DIRS})
-  endif (POPT_FOUND)
-endif (BUILD_RDIFF)
+find_package(POPT)
+if (POPT_FOUND)
+  include_directories(${POPT_INCLUDE_DIRS})
+endif (POPT_FOUND)
 
 # Find BZIP
 find_package (BZip2)
@@ -142,7 +149,6 @@ if (BZIP2_FOUND)
   message (STATUS "BZIP2_INCLUDE_DIR  = ${BZIP2_INCLUDE_DIR}")
   message (STATUS "BZIP2_LIBRARIES = ${BZIP2_LIBRARIES}")
   include_directories(${BZIP2_INCLUDE_DIR})
-  list(APPEND rsync_LIB_DEPS ${BZIP2_LIBRARIES})
 endif (BZIP2_FOUND)
 
 # Find Perl
@@ -158,7 +164,6 @@ if (ZLIB_FOUND)
   message (STATUS "ZLIB_INCLUDE_DIR  = ${ZLIB_INCLUDE_DIR}")
   message (STATUS "ZLIB_LIBRARIES = ${ZLIB_LIBRARIES}")
   include_directories(${ZLIB_INCLUDE_DIRS})
-  list(APPEND rsync_LIB_DEPS ${ZLIB_LIBRARIES})
 endif (ZLIB_FOUND)
 
 # Doxygen doc generator
@@ -264,7 +269,16 @@ set(rsync_LIB_SRCS
 
 add_library(rsync SHARED ${rsync_LIB_SRCS})
 
-target_link_libraries(rsync ${rsync_LIB_DEPS})
+# Optionally link zlib and bzip2 if
+# - compression is enabled
+# - and libraries are found
+if (ENABLE_COMPRESSION)
+  if (ZLIB_FOUND AND BZIP2_FOUND)
+    target_link_libraries(rsync ${ZLIB_LIBRARIES} ${BZIP2_LIBRARIES})
+  else (ZLIB_FOUND AND BZIP2_FOUND)
+    message (WARNING "zlib and bzip2 librares are required to enable compression")
+  endif (ZLIB_FOUND AND BZIP2_FOUND)
+endif (ENABLE_COMPRESSION)
 
 set_target_properties(rsync PROPERTIES VERSION ${LIBRSYNC_VERSION}
         SOVERSION ${LIBRSYNC_MAJOR_VERSION})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,23 +188,26 @@ execute_process(COMMAND ${PERL_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/src/mkpr
 
 # Testing
 
-add_test(NAME rdiff_bad_option
-         COMMAND rdiff_bad_option.sh ${CMAKE_CURRENT_BINARY_DIR}
-         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-
 add_executable(isprefix_test
     tests/isprefix_test.c src/isprefix.c)
-
+    
 add_test(NAME isprefix_test COMMAND isprefix_test)
 
-add_test(NAME Help COMMAND help.test ${CMAKE_CURRENT_BINARY_DIR} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-
-add_test(NAME Mutate COMMAND mutate.test ${CMAKE_CURRENT_BINARY_DIR} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-add_test(NAME Signature COMMAND signature.test ${CMAKE_CURRENT_BINARY_DIR} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-add_test(NAME Sources COMMAND sources.test ${CMAKE_CURRENT_BINARY_DIR} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-add_test(NAME Triple COMMAND triple.test ${CMAKE_CURRENT_BINARY_DIR} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-add_test(NAME Delta COMMAND delta.test ${CMAKE_CURRENT_BINARY_DIR} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-add_test(NAME Changes COMMAND changes.test ${CMAKE_CURRENT_BINARY_DIR} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+# Disable rdiff specific tests
+if (BUILD_RDIFF)
+    add_test(NAME rdiff_bad_option
+             COMMAND rdiff_bad_option.sh ${CMAKE_CURRENT_BINARY_DIR}
+             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+    
+    add_test(NAME Help COMMAND help.test ${CMAKE_CURRENT_BINARY_DIR} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+    
+    add_test(NAME Mutate COMMAND mutate.test ${CMAKE_CURRENT_BINARY_DIR} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+    add_test(NAME Signature COMMAND signature.test ${CMAKE_CURRENT_BINARY_DIR} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+    add_test(NAME Sources COMMAND sources.test ${CMAKE_CURRENT_BINARY_DIR} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+    add_test(NAME Triple COMMAND triple.test ${CMAKE_CURRENT_BINARY_DIR} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+    add_test(NAME Delta COMMAND delta.test ${CMAKE_CURRENT_BINARY_DIR} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+    add_test(NAME Changes COMMAND changes.test ${CMAKE_CURRENT_BINARY_DIR} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+endif (BUILD_RDIFF)
 
 
 # `make check` that will build everything and then run the tests.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,11 +277,14 @@ if (BUILD_RDIFF)
   set(rdiff_SRCS
       src/rdiff.c
       src/isprefix.c)
-  
+
   add_executable(rdiff ${rdiff_SRCS})
-  
-  target_link_libraries(rdiff rsync ${POPT_LIBRARIES})
-  
+  if (POPT_FOUND)
+    target_link_libraries(rdiff rsync ${POPT_LIBRARIES})
+  else (POPT_FOUND)
+    message (WARNING "Popt library is required for rdiff target")
+  endif (POPT_FOUND)
+
   install(TARGETS rdiff ${INSTALL_TARGETS_DEFAULT_ARGS} DESTINATION bin)
 endif (BUILD_RDIFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,11 @@ option(BUILD_RDIFF "Whether or not to build rdiff executable" ON)
 
 # Add an option to include compression support
 option(ENABLE_COMPRESSION "Whether or not to build with compression support" OFF)
+# TODO: Remove this warning when compression is implemented.
+#       Consider turning compression ON by default.
+if (ENABLE_COMPRESSION)
+    message(WARNING "Compression support is not functional. See issue #8.")
+endif (ENABLE_COMPRESSION)
 
 include ( CheckIncludeFiles )
 check_include_files ( alloca.h HAVE_ALLOCA_H )

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,10 @@ NOT RELEASED YET
    tests and could fail if they weren't built.
    (Martin Pool, https://github.com/librsync/librsync/issues/49)
 
+ * Added cmake options to exclude rdiff target and compression from build.
+   See install documentation for details.
+   Thanks to Michele Bertasi.
+
 ## librsync 2.0.0
 
 Released 2015-11-29

--- a/doc/install.md
+++ b/doc/install.md
@@ -30,7 +30,7 @@ Generate the Makefile by running
 After building you can install `rdiff` and `librsync` for system-wide use.
 
     $ make
-    
+
 To build and run the tests:
 
     $ make check
@@ -38,7 +38,7 @@ To build and run the tests:
 To install:
 
     $ sudo make install
-    
+
 To build the documentation:
 
     $ make doc
@@ -53,6 +53,25 @@ If you are using GNU libc, you might like to use
 to detect some allocation bugs.
 
 librsync has annotations for the SPLINT static checking tool.
+
+
+## Build options
+
+The build is customizable by using CMake options in the configure step:
+
+    $ cmake -D <option-name>=<value> .
+
+If you are interested in building only the `librsync` target, you can skip
+the `rdiff` build. In this way you don't need its dependencies (e.g. `popt`).
+To do that, set the `BUILD_RDIFF` option to `OFF`:
+
+    $ cmake -D BUILD_RDIFF=OFF .
+
+Compression support is under development (see
+[#8](https://github.com/librsync/librsync/issues/8)). It is so disabled by
+default. You can turn it on by using `ENABLE_COMPRESSION` option:
+
+    $ cmake -D ENABLE_COMPRESSION=ON .
 
 
 ## Ninja builds

--- a/doc/install.md
+++ b/doc/install.md
@@ -67,6 +67,9 @@ To do that, set the `BUILD_RDIFF` option to `OFF`:
 
     $ cmake -D BUILD_RDIFF=OFF .
 
+Be aware that many tests depend on `rdiff` executable, so when it is disabled,
+also those tests are.
+
 Compression support is under development (see
 [#8](https://github.com/librsync/librsync/issues/8)). It is so disabled by
 default. You can turn it on by using `ENABLE_COMPRESSION` option:


### PR DESCRIPTION
I've tweaked the build process a bit. I have the need to minimize build dependencies, and so I made the following changes:
* Added an option (default ON) to build the `rdiff` target;
* Added an option (default OFF) to build with compression support;
* Made `zlib` and `bzip2` libraries optional.

This allows me to build only the `rsync` library (and not `rdiff`), and thus avoid having `popt` dependency. Moreover, `zlib` and `bzip2` use can be disabled.

The removal of `REQUIRED` attribute in `find_package` turns an hard error in a soft one, and does not stop the generation step. This allows the user to tweak parameters after generation with CMake.

The compression support is not implemented for now, so I've kept it OFF by default. When the support is present, you can make the option ON by default!

Let me know what you think.