### PR TITLE
Avoid useless allocation in COPY command

### DIFF
--- a/src/patch.c
+++ b/src/patch.c
@@ -222,7 +222,7 @@ static rs_result rs_patch_s_copying(rs_job_t *job)
     rs_trace("copy " PRINTF_FORMAT_U64 " bytes from basis at offset " PRINTF_FORMAT_U64 "",
              PRINTF_CAST_U64(len), PRINTF_CAST_U64(job->basis_pos));
 
-    ptr = buf = rs_alloc(len, "basis buffer");
+    ptr = buf = buffs->next_out;
     
     result = (job->copy_cb)(job->copy_arg, job->basis_pos, &len, &ptr);
     if (result != RS_DONE)
@@ -232,15 +232,14 @@ static rs_result rs_patch_s_copying(rs_job_t *job)
     
     rs_trace("got " PRINTF_FORMAT_U64 " bytes back from basis callback", PRINTF_CAST_U64(len));
 
-    memcpy(buffs->next_out, ptr, len);
+    if (ptr != buf)
+        memcpy(buffs->next_out, ptr, len);
 
     buffs->next_out += len;
     buffs->avail_out -= len;
 
     job->basis_pos += len;
     job->basis_len -= len;
-
-    free(buf);
 
     if (!job->basis_len) {
         /* Done! */

--- a/src/patch.c
+++ b/src/patch.c
@@ -209,7 +209,7 @@ static rs_result rs_patch_s_copying(rs_job_t *job)
 {
     rs_result       result;
     size_t          len;
-    void            *buf, *ptr;
+    void            *ptr;
     rs_buffers_t    *buffs = job->stream;
 
     /* copy only as much as will fit in the output buffer, so that we
@@ -222,7 +222,7 @@ static rs_result rs_patch_s_copying(rs_job_t *job)
     rs_trace("copy " PRINTF_FORMAT_U64 " bytes from basis at offset " PRINTF_FORMAT_U64 "",
              PRINTF_CAST_U64(len), PRINTF_CAST_U64(job->basis_pos));
 
-    ptr = buf = buffs->next_out;
+    ptr = buffs->next_out;
     
     result = (job->copy_cb)(job->copy_arg, job->basis_pos, &len, &ptr);
     if (result != RS_DONE)
@@ -232,7 +232,8 @@ static rs_result rs_patch_s_copying(rs_job_t *job)
     
     rs_trace("got " PRINTF_FORMAT_U64 " bytes back from basis callback", PRINTF_CAST_U64(len));
 
-    if (ptr != buf)
+    /* copy back to out buffer only if the callback has used its own buffer */
+    if (ptr != buffs->next_out)
         memcpy(buffs->next_out, ptr, len);
 
     buffs->next_out += len;


### PR DESCRIPTION
I found useless allocations in the execution of COPY command, in the context of patch application.
The program flow was basically this:
* allocate a buffer that fits within the output buffer (`patch.c:225`);
* pass that to the copy callback (`patch.c:227`);
* the callback is free to use another buffer if she wants (documentation of `rs_copy_cb` at `librsync.h:528`);
* copy the buffer (the one used by the callback) to the output buffer;
* free the allocated buffer.

I've changed the flow in this way:
* allocate nothing!
* pass the output buffer directly to the copy callback; this is safe, since the previously allocated buffer was no bigger than the output buffer (see `patch.c:217`);
* the callback is still free to use another buffer;
* copy the buffer to the output buffer if the callback has used another buffer;
* free nothing!

What do you think? This seems a big performance gain, since this function is called many many times (multiple calls per single COPY command indeed).