### PR TITLE
Fixed MSVC build under Windows

### DIFF
--- a/src/version.c
+++ b/src/version.c
@@ -20,7 +20,6 @@
  */
 
 #include "config.h"
-#include "librsync.h"
 
 
 char const rs_librsync_version[] = (PACKAGE " " VERSION);


### PR DESCRIPTION
Removed `librsync.h` include from `version.c`. The build was failing
because `stdlib.h` include was missing, and so `size_t` type not found.
There were two options to fix that: either remove `librsync.h` include,
or add also `stdlib.h` include. Since they were both not used by
`version.c`, I've chosen to remove them.