### PR TITLE
Open stdout and stdin in _O_BINARY mode on Windows.

### DIFF
--- a/src/fileutil.c
+++ b/src/fileutil.c
@@ -57,10 +57,17 @@ rs_file_open(char const *filename, char const *mode)
     is_write = mode[0] == 'w';
 
     if (!filename  ||  !strcmp("-", filename)) {
-	if (is_write)
+	if (is_write) {
+#if _WIN32
+	    _setmode(_fileno(stdout), _O_BINARY);
+#endif
 	    return stdout;
-	else
+	} else {
+#if _WIN32
+	    _setmode(_fileno(stdin), _O_BINARY);
+#endif
 	    return stdin;
+	}
     }
 
     if (!(f = fopen(filename, mode))) {

--- a/tests/triple.test
+++ b/tests/triple.test
@@ -29,11 +29,20 @@ do
     do
         for new in $inputdir/*.in
         do
-            for hashopt in $all_hashopts
+            for hashopt in -Hmd4 -Hblake2
             do
                 run_test ../rdiff $debug $hashopt -I$buf -O$buf signature $old $tmpdir/sig
                 run_test ../rdiff $debug $hashopt -I$buf -O$buf delta $tmpdir/sig $new $tmpdir/delta
                 run_test ../rdiff $debug $hashopt -I$buf -O$buf patch $old $tmpdir/delta $tmpdir/new
+
+                check_compare $new $tmpdir/new "triple -I$buf -O$buf $old $new"
+
+                # Run tests again and check if reading and writing to pipes works
+                :> $tmpdir/new
+                cat $old | run_test ../rdiff $debug $hashopt -I$buf -O$buf signature > $tmpdir/sig
+                # this test pipes signature instead of $new so that signature memory preallocation is tested
+                cat $tmpdir/sig | run_test ../rdiff $debug $hashopt -I$buf -O$buf delta - $new > $tmpdir/delta
+                cat $tmpdir/delta | run_test ../rdiff $debug $hashopt -I$buf -O$buf patch $old > $tmpdir/new
 
                 check_compare $new $tmpdir/new "triple -I$buf -O$buf $old $new"
             done


### PR DESCRIPTION
As part of realloc patch, I wrote a test for rdiff using pipes. I discovered a CRITICAL problem! On Windows ALL output written to stdout has LF changed to CRLF. This CORRUPTS binary data and all signatures and deltas written to stdout are wrong!

Since this test was not running, I also added a quick fix for issue #71 