### PR TITLE
Check that off64_t exists before declaring it as RS_LONG_T.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ check_type_size ( "unsigned short" SIZEOF_UNSIGNED_SHORT )
 # rs_long_t is that we need to be able to seek to it, which relates to
 # long file support. With fseeko, rs_long_t should be off_t, otherwise
 # it should be long.
-if ( HAVE_FSEEKO64 )
+if ( HAVE_FSEEKO64 AND SIZEOF_OFF64_T )
   set( RS_LONG_T "off64_t" )
   message (STATUS "RS_LONG_T = off64_t")
 elseif ( HAVE_SYS_TYPES_H AND LONG_LONG )


### PR DESCRIPTION
This is a mistake in my previous mingw patch. I noticed my Centos6 64-bit supports fseeko64, but fails off64_t size check. It does compile for some reason in the end, but it's an inconsistency. fseeko is preferred to fseeko64 in buf.c, let's not declare off64_t if it isn't found.