### PR TITLE
faster hash table using open addressing

### DIFF
--- a/src/delta.c
+++ b/src/delta.c
@@ -443,7 +443,7 @@ static rs_result rs_delta_s_header(rs_job_t *job)
 rs_job_t *rs_delta_begin(rs_signature_t *sig)
 {
     /* Caller must have called rs_build_hash_table() by now */
-    if (!sig->tag_table)
+    if (!sig->buckets)
         rs_fatal("Must call rs_build_hash_table() prior to calling rs_delta_begin()");
 
     rs_job_t *job;

--- a/src/readsums.c
+++ b/src/readsums.c
@@ -67,7 +67,6 @@ static rs_result rs_loadsig_add_sum(rs_job_t *job, rs_strong_sum_t *strong)
     asignature = &(sig->block_sigs[sig->count - 1]);
 
     asignature->weak_sum = job->weak_sig;
-    asignature->i = sig->count;
 
     memcpy(asignature->strong_sum, strong, sig->strong_sum_len);
 

--- a/src/search.c
+++ b/src/search.c
@@ -2,6 +2,7 @@
  *
  * librsync -- the library for network deltas
  *
+ * Copyright (C) 2016 by Martin Nowak <code@dawg.eu>
  * Copyright (C) 1999, 2000, 2001, 2014 by Martin Pool <mbp@sourcefrog.net>
  * Copyright (C) 1999 by Andrew Tridgell
  *
@@ -45,110 +46,102 @@
 #include "search.h"
 #include "checksum.h"
 
-#define TABLE_SIZE (1<<16)
-#define NULL_TAG (-1)
+// maximum load factor of hash table
+#define LOAD_FACTOR_NUM 7
+#define LOAD_FACTOR_DEN 10
 
-#define gettag2(s1,s2) (((s1) + (s2)) & 0xFFFF)
-#define gettag(sum) gettag2((sum)&0xFFFF,(sum)>>16)
-
-static void swap(rs_target_t *t1, rs_target_t *t2) {
-    unsigned short ts = t1->t;
-    t1->t = t2->t;
-    t2->t = ts;
-
-    int ti = t1->i;
-    t1->i = t2->i;
-    t2->i = ti;
-}
-
-static int rs_compare_targets(rs_target_t const *t1, rs_target_t const *t2, rs_signature_t * sums) {
-    int v = (int) t1->t - (int) t2->t;
-    if (v != 0)
-        return v;
-
-    rs_weak_sum_t w1 = sums->block_sigs[t1->i].weak_sum;
-    rs_weak_sum_t w2 = sums->block_sigs[t2->i].weak_sum;
-
-    v = (w1 > w2) - (w1 < w2);
-    if (v != 0)
-        return v;
-
-    return memcmp(sums->block_sigs[t1->i].strong_sum,
-            sums->block_sigs[t2->i].strong_sum,
-            sums->strong_sum_len);
-}
-
-static void heap_sort(rs_signature_t * sums) {
-    unsigned int i, j, n, k, p;
-    for (i = 1; i < sums->count; ++i) {
-        for (j = i; j > 0;) {
-            p = (j - 1) >> 1;
-            if (rs_compare_targets(&sums->targets[j], &sums->targets[p], sums) > 0)
-                swap(&sums->targets[j], &sums->targets[p]);
-            else
-                break;
-            j = p;
-        }
-    }
-
-    for (n = sums->count - 1; n > 0;) {
-        swap(&sums->targets[0], &sums->targets[n]);
-        --n;
-        for (i = 0; ((i << 1) + 1) <= n;) {
-            k = (i << 1) + 1;
-            if ((k + 1 <= n) && (rs_compare_targets(&sums->targets[k], &sums->targets[k + 1], sums) < 0))
-                k = k + 1;
-            if (rs_compare_targets(&sums->targets[k], &sums->targets[i], sums) > 0)
-                swap(&sums->targets[k], &sums->targets[i]);
-            else
-                break;
-            i = k;
-        }
-    }
-}
-
-rs_result
-rs_build_hash_table(rs_signature_t * sums)
+static unsigned int next_pow_2(unsigned int v)
 {
-    int i;
+    if (v < 2) return v;
+    return (1U << (32 - __builtin_clz(v - 1)));
+}
 
-    sums->tag_table = calloc(TABLE_SIZE, sizeof(sums->tag_table[0]));
-    if (!sums->tag_table)
+static bool insert_entry(rs_signature_t *sigs, const rs_block_sig_t *block_sig, unsigned int strong_idx)
+{
+    const unsigned int mask = sigs->bucket_len - 1;
+    size_t i, step;
+    for (i = block_sig->weak_sum & mask, step = 0; ; i = (i + ++step) & mask)
+    {
+        if (sigs->buckets[i].strong_idx == 0) // empty bucket
+        {
+            sigs->buckets[i].weak_sum = block_sig->weak_sum;
+            sigs->buckets[i].strong_idx = strong_idx + 1;
+            memcpy(sigs->strong_sums[strong_idx], block_sig->strong_sum, sigs->strong_sum_len);
+            return true;
+        }
+        else if (sigs->buckets[i].weak_sum == block_sig->weak_sum &&
+                 memcmp(block_sig->strong_sum, sigs->strong_sums[sigs->buckets[i].strong_idx - 1], sigs->strong_sum_len) == 0)
+        {
+            return false;
+        }
+
+    }
+}
+
+static unsigned int lookup_entry(const rs_signature_t *sigs, rs_weak_sum_t weak_sum, const rs_byte_t *inbuf, size_t block_len)
+{
+    rs_strong_sum_t strong_sum;
+    bool has_strong_sum = false;
+
+    const unsigned int mask = sigs->bucket_len - 1;
+    size_t i, step;
+    for (i = weak_sum & mask, step = 0; ; i = (i + ++step) & mask)
+    {
+        if (sigs->buckets[i].strong_idx == 0) // empty bucket
+            return -1;
+        if (sigs->buckets[i].weak_sum != weak_sum)
+            continue;
+        if (!has_strong_sum)
+        {
+            if (sigs->magic == RS_BLAKE2_SIG_MAGIC)
+                rs_calc_blake2_sum(inbuf, block_len, &strong_sum);
+            else if (sigs->magic == RS_MD4_SIG_MAGIC)
+                rs_calc_md4_sum(inbuf, block_len, &strong_sum);
+            else
+            {
+                /* Bad input data is checked in rs_delta_begin, so this
+                 * should never be reached. */
+                rs_fatal("Unknown signature algorithm %#x", sigs->magic);
+                return -1;
+            }
+            has_strong_sum = true;
+        }
+
+        if (memcmp(strong_sum, sigs->strong_sums[sigs->buckets[i].strong_idx - 1], sigs->strong_sum_len) == 0)
+            return sigs->buckets[i].strong_idx - 1;
+    }
+}
+
+rs_result rs_build_hash_table(rs_signature_t *sigs)
+{
+    sigs->bucket_len = sigs->count ? next_pow_2((sigs->count * LOAD_FACTOR_DEN + LOAD_FACTOR_NUM - 1) / LOAD_FACTOR_NUM) : 1;
+    sigs->buckets = calloc(sigs->bucket_len, sizeof(sigs->buckets[0]));
+    if (!sigs->buckets)
         return RS_MEM_ERROR;
 
-    if (sums->count > 0) {
-        sums->targets = calloc(sums->count, sizeof(rs_target_t));
-        if (!sums->targets) {
-            free(sums->tag_table);
-            sums->tag_table = NULL;
-            return RS_MEM_ERROR;
-        }
-
-        for (i = 0; i < sums->count; i++) {
-            sums->targets[i].i = i;
-            sums->targets[i].t = gettag(sums->block_sigs[i].weak_sum);
-        }
-
-        heap_sort(sums);
+    sigs->strong_sums = calloc(sigs->count, sizeof(sigs->strong_sums[0]));
+    if (!sigs->strong_sums)
+    {
+        free(sigs->buckets);
+        sigs->buckets = NULL;
+        return RS_MEM_ERROR;
     }
 
-    for (i = 0; i < TABLE_SIZE; i++) {
-        sums->tag_table[i].l = NULL_TAG;
-        sums->tag_table[i].r = NULL_TAG;
+    size_t strong_idx = 0;
+    size_t i;
+    for (i = 0; i < sigs->count; ++i)
+    {
+        if (insert_entry(sigs, &sigs->block_sigs[i], strong_idx)) // sort out duplicates
+            ++strong_idx;
     }
 
-    for (i = sums->count - 1; i >= 0; i--) {
-        sums->tag_table[sums->targets[i].t].l = i;
-    }
-
-    for (i = 0; i < sums->count; i++) {
-        sums->tag_table[sums->targets[i].t].r = i;
-    }
+    // no longer needed
+    free(sigs->block_sigs);
+    sigs->block_sigs = NULL;
 
     rs_trace("rs_build_hash_table done");
     return RS_DONE;
 }
-
 
 
 /*
@@ -160,87 +153,20 @@ rs_build_hash_table(rs_signature_t * sums)
  * strong checksum for the current block, and see if it will match
  * anything.
  */
-int
-rs_search_for_block(rs_weak_sum_t weak_sum,
+bool rs_search_for_block(rs_weak_sum_t weak_sum,
                     const rs_byte_t *inbuf,
                     size_t block_len,
-                    rs_signature_t const *sig, rs_stats_t * stats,
+                    rs_signature_t const *sigs, rs_stats_t *stats,
                     rs_long_t * match_where)
 {
     /* Caller must have called rs_build_hash_table() by now */
-    if (!sig->tag_table)
+    if (!sigs->buckets)
         rs_fatal("Must have called rs_build_hash_table() by now");
 
-    rs_strong_sum_t strong_sum;
-    int got_strong = 0;
-    int hash_tag = gettag(weak_sum);
-    rs_tag_table_entry_t *bucket = &(sig->tag_table[hash_tag]);
-    int l = bucket->l; /* left bound of search region */
-    int r = bucket->r + 1; /* right bound of search region */
-    int v = 1; /* direction of next move: -ve left, +ve right */
+    const unsigned int strong_idx = lookup_entry(sigs, weak_sum, inbuf, block_len);
+    if (strong_idx == -1)
+        return false;
 
-    if (l == NULL_TAG)
-        return 0;
-
-    while (l < r) {
-        int m = (l + r) >> 1; /* midpoint of search region */
-        int i = sig->targets[m].i;
-        rs_block_sig_t *b = &(sig->block_sigs[i]);
-        v = (weak_sum > b->weak_sum) - (weak_sum < b->weak_sum);
-        // v < 0  - weak_sum <  b->weak_sum
-        // v == 0 - weak_sum == b->weak_sum
-        // v > 0  - weak_sum >  b->weak_sum
-
-        if (v == 0) {
-            if (!got_strong) {
-                /* Lazy calculate strong sum after finding weak match. */
-                if(sig->magic == RS_BLAKE2_SIG_MAGIC) {
-                    rs_calc_blake2_sum(inbuf, block_len, &strong_sum);
-                } else if (sig->magic == RS_MD4_SIG_MAGIC) {
-                    rs_calc_md4_sum(inbuf, block_len, &strong_sum);
-                } else {
-                    /* Bad input data is checked in rs_delta_begin, so this
-                     * should never be reached. */
-                    rs_fatal("Unknown signature algorithm %#x", sig->magic);
-                    return 0;
-                }
-                got_strong = 1;
-            }
-            v = memcmp(strong_sum, b->strong_sum, sig->strong_sum_len);
-
-            if (v == 0) {
-                l = m;
-                r = m;
-                break;
-            }
-        }
-
-        if (v > 0)
-            l = m + 1;
-        else
-            r = m;
-    }
-
-    if ((l == r) && (l <= bucket->r)) {
-        int i = sig->targets[l].i;
-        rs_block_sig_t *b = &(sig->block_sigs[i]);
-        if (weak_sum != b->weak_sum)
-            return 0;
-        if (!got_strong) {
-            if(sig->magic == RS_BLAKE2_SIG_MAGIC) {
-                rs_calc_blake2_sum(inbuf, block_len, &strong_sum);
-            } else if (sig->magic == RS_MD4_SIG_MAGIC) {
-                rs_calc_md4_sum(inbuf, block_len, &strong_sum);
-            } else {
-                rs_error("Unknown signature algorithm - this is a BUG");
-                return 0; /* FIXME: Is this the best way to handle this? */
-            }
-            got_strong = 1;
-        }
-        v = memcmp(strong_sum, b->strong_sum, sig->strong_sum_len);
-        int token = b->i;
-        *match_where = (rs_long_t)(token - 1) * sig->block_len;
-    }
-
-    return !v;
+    *match_where = (rs_long_t) strong_idx * sigs->block_len;
+    return true;
 }

--- a/src/search.h
+++ b/src/search.h
@@ -20,7 +20,9 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-int
+#include <stdbool.h>
+
+bool
 rs_search_for_block(rs_weak_sum_t weak_sum,
                     const rs_byte_t *inbuf,
                     size_t block_len,

--- a/src/sumset.c
+++ b/src/sumset.c
@@ -38,11 +38,11 @@ rs_free_sumset(rs_signature_t * psums)
         if (psums->block_sigs)
                 free(psums->block_sigs);
 
-        if (psums->tag_table)
-		free(psums->tag_table);
+        if (psums->buckets)
+		free(psums->buckets);
 
-        if (psums->targets)
-                free(psums->targets);
+        if (psums->strong_sums)
+                free(psums->strong_sums);
 
         rs_bzero(psums, sizeof *psums);
         free(psums);

--- a/src/sumset.h
+++ b/src/sumset.h
@@ -2,6 +2,7 @@
  *
  * librsync -- the library for network deltas
  * 
+ * Copyright (C) 2016 by Martin Nowak <code@dawg.eu>
  * Copyright (C) 1999, 2000, 2001 by Martin Pool <mbp@sourcefrog.net>
  * Copyright (C) 1999 by Andrew Tridgell <tridge@samba.org>
  * 
@@ -20,29 +21,22 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
+/**
+ * \brief Hash bucket
+ */
+typedef struct rs_hash_bucket {
+    rs_weak_sum_t weak_sum;
+    unsigned int strong_idx;
+} rs_hash_bucket_t;
 
 /*
- * TODO: These structures are not terribly useful.  Perhaps we need a
- * splay tree or something that will let us smoothly grow as data is
- * read in.
+ * All blocks are the same length in the current algorithm except for
+ * the last block which may be short.
  */
-
-
-/**
- * \brief Description of the match described by a signature.
- */
-typedef struct rs_target {
-    unsigned short  t;
-    int             i;
-} rs_target_t;
-
-typedef struct rs_block_sig rs_block_sig_t;
-
-typedef struct rs_tag_table_entry {
-    int l; // left bound of the hash tag in sorted array of targets
-    int r; // right bound of the hash tag in sorted array of targets
-    // all tags between l and r inclusively are the same
-} rs_tag_table_entry_t ;
+typedef struct rs_block_sig {
+    rs_weak_sum_t   weak_sum;	/* simple checksum */
+    rs_strong_sum_t strong_sum;	/* checksum  */
+} rs_block_sig_t;
 
 /*
  * This structure describes all the sums generated for an instance of
@@ -50,24 +44,14 @@ typedef struct rs_tag_table_entry {
  * search.
  */
 struct rs_signature {
+    rs_hash_bucket_t *buckets; /* hash table to look up weak sums */
+    rs_strong_sum_t *strong_sums; /* strong hash sums */
+    unsigned int bucket_len;
+    int strong_sum_len;
+    rs_block_sig_t *block_sigs; /* as read from on-disk format */
     rs_long_t       flength;	/* total file length */
+    int             magic;
     int             count;      /* how many chunks */
     int             remainder;	/* flength % block_length */
     int             block_len;	/* block_length */
-    int             strong_sum_len;
-    rs_block_sig_t  *block_sigs; /* points to info for each chunk */
-    rs_tag_table_entry_t	*tag_table;
-    rs_target_t     *targets;
-    int             magic;
-};
-
-
-/*
- * All blocks are the same length in the current algorithm except for
- * the last block which may be short.
- */
-struct rs_block_sig {
-    int             i;		/* index of this chunk */
-    rs_weak_sum_t   weak_sum;	/* simple checksum */
-    rs_strong_sum_t strong_sum;	/* checksum  */
 };


### PR DESCRIPTION
- replace fixed size hash table with a fitted open addressing one
- size of table is next_pow_2(count / load_factor)
- collisions are resolved w/ a variant of quadratic probing using triangular numbers
- mix 32 bits of rolling adler32 sum for much fewer collisions
