### PR TITLE
[RFC] Implement optional full block matching

### DIFF
--- a/src/delta.c
+++ b/src/delta.c
@@ -180,6 +180,10 @@ static rs_result rs_delta_s_scan(rs_job_t *job)
                 RollsumInit(&job->weak_sum);
             }
         }
+
+        if (job->block_match > 0) {
+            job->block_match++;
+        }
     }
     /* if we completed OK */
     if (result==RS_DONE) {
@@ -207,6 +211,8 @@ static rs_result rs_delta_s_flush(rs_job_t *job)
     rs_getinput(job);
     /* output any pending output */
     result=rs_tube_catchup(job);
+    /* tokens should no longer be valid */
+    job->block_match = -1;
     /* while output is not blocked and there is any remaining data */
     while ((result==RS_DONE) && (job->scoop_pos < job->scoop_avail)) {
         /* check if this block matches */
@@ -280,7 +286,7 @@ inline int rs_findmatch(rs_job_t *job, rs_long_t *match_pos, size_t *match_len) 
                                *match_len,
                                job->signature,
                                &job->stats,
-                               match_pos);
+                               match_pos, job->block_match);
 }
 
 

--- a/src/job.h
+++ b/src/job.h
@@ -45,6 +45,9 @@ struct rs_job {
      * they're also used in the mksum operation. */
     int                 block_len;
     int                 strong_sum_len;
+
+    /** block_match is the current block being processed, only valid
+        when block_match is set (starts at 1) */
     int                 block_match;
 
     /** Signature that's either being read in, or used for

--- a/src/job.h
+++ b/src/job.h
@@ -45,6 +45,7 @@ struct rs_job {
      * they're also used in the mksum operation. */
     int                 block_len;
     int                 strong_sum_len;
+    int                 block_match;
 
     /** Signature that's either being read in, or used for
      * generating a delta. */

--- a/src/librsync.h
+++ b/src/librsync.h
@@ -488,10 +488,13 @@ rs_job_t *rs_sig_begin(size_t new_block_len,
 /**
  * Prepare to compute a streaming delta.
  *
+ * \param block_match Indicates that full block matching should be made
+ * (no rolling checksum)
+ *
  * \todo Add a version of this that takes a ::rs_magic_number controlling the
  * delta format.
  **/
-rs_job_t *rs_delta_begin(rs_signature_t *);
+rs_job_t *rs_delta_begin(rs_signature_t *, int block_match);
 
 
 /**
@@ -613,7 +616,7 @@ rs_result rs_file_copy_cb(void *arg, rs_long_t pos, size_t *len, void **buf);
  * Generate a delta between a signature and a new file, int a delta file.
  * \sa \ref api_whole
  **/
-rs_result rs_delta_file(rs_signature_t *, FILE *new_file, FILE *delta_file, rs_stats_t *);
+rs_result rs_delta_file(rs_signature_t *, FILE *new_file, FILE *delta_file, rs_stats_t *, int);
 
 
 /**

--- a/src/rdiff.c
+++ b/src/rdiff.c
@@ -70,6 +70,7 @@
 
 #define PROGRAM "rdiff"
 
+static int block_match = 0;
 static size_t block_len = RS_DEFAULT_BLOCK_LEN;
 static size_t strong_len = 0;
 
@@ -95,6 +96,7 @@ const struct poptOption opts[] = {
     { "help",        '?', POPT_ARG_NONE, 0,             'h' },
     {  0,            'h', POPT_ARG_NONE, 0,             'h' },
     { "block-size",  'b', POPT_ARG_INT,  &block_len },
+    { "block-match", 'm', POPT_ARG_NONE, &block_match },
     { "sum-size",    'S', POPT_ARG_INT,  &strong_len },
     { "statistics",  's', POPT_ARG_NONE, &show_stats },
     { "stats",        0,  POPT_ARG_NONE, &show_stats },
@@ -144,6 +146,7 @@ static void help(void) {
            "  -H, --hash=ALG            Hash algorithm: blake2 (default), md4\n"
            "Delta-encoding options:\n"
            "  -b, --block-size=BYTES    Signature block size\n"
+           "  -m, --block-match         Enable matching only full blocks\n"
            "  -S, --sum-size=BYTES      Set signature strength\n"
            "      --paranoia            Verify all rolling checksums\n"
            "IO options:\n"
@@ -308,7 +311,7 @@ static rs_result rdiff_delta(poptContext opcon)
     if ((result = rs_build_hash_table(sumset)) != RS_DONE)
         return result;
 
-    result = rs_delta_file(sumset, new_file, delta_file, &stats);
+    result = rs_delta_file(sumset, new_file, delta_file, &stats, block_match);
 
     rs_free_sumset(sumset);
 

--- a/src/search.h
+++ b/src/search.h
@@ -25,5 +25,5 @@ rs_search_for_block(rs_weak_sum_t weak_sum,
                     const rs_byte_t *inbuf,
                     size_t block_len,
                     rs_signature_t const *sums, rs_stats_t * stats,
-                    rs_long_t * match_where);
+                    rs_long_t * match_where, int job_token);
 

--- a/src/whole.c
+++ b/src/whole.c
@@ -129,12 +129,12 @@ rs_loadsig_file(FILE *sig_file, rs_signature_t **sumset, rs_stats_t *stats)
 
 rs_result
 rs_delta_file(rs_signature_t *sig, FILE *new_file, FILE *delta_file,
-              rs_stats_t *stats)
+              rs_stats_t *stats, int block_match)
 {
     rs_job_t            *job;
     rs_result           r;
 
-    job = rs_delta_begin(sig);
+    job = rs_delta_begin(sig, block_match);
 
     r = rs_whole_run(job, new_file, delta_file);
 


### PR DESCRIPTION
Hi,

librsync at the moment uses rolling checksum to compare and find each possible matching block for the given signature. This is great for files which change and move existing content (mbox mailboxes for example) and provides the most optimal delta (given limited bandwidth for example). However, for some other content, this is rarely useful. It's highly unlikely that filesystem image (virtual machine disk) for example will move existing block to a different location. Even if signature block size would match filesystem block size, it's unlikely that a block will be copied exactly to some different location within the filesystem without a single byte changed.

For files that store content in blocks that don't arbitrarily move within the file, the rolling checksum does not provide any advantage and only increases the load (and collision possibility) by check-summing each and every byte. It would therefore better to allow only full (sig size) block matching in those cases. Virtual machine disk images for example can be huge. Storing deltas for such files (backups for example) usually happens over LAN, so optimizing local I/O and CPU usage to speed up processing is preferable over getting a slightly smaller delta (if it's smaller at all) and conserving bandwidth.

Block match is activated with -m parameter. When it's active and the current block is not found in the signature, entire sig-size block will be marked not-matching (rs_appendmiss) and sums will be re-initialized from the next signature block. This is v2 of the patch, I had a v1 where the block match size would not have to be the same as signature block size (for instance, searching a file by moving the checksum window 512-bytes in a 2048-byte blocks), but the code was much more complicated. Having the window only move in signature-size blocks is much more simple and arbitrary size would hardly provide any benefit in this case (if it does, then normal rolling checksum mode can be used).

By moving the search window in sig-size blocks allows for additional improvements, not possible (or significantly harder to implement) with the current algorithm:
- we can mach exactly the same block in the source file first, before searching for other matching blocks (optimizes delta - included in the second part of the PR)
- patching could be improved to support in-line patching (w/o copying the destination file)
- an inverse-delta could be created at the same time, while doing an inline patch of the destination file
- ...

The usage case for this mode would be any file that stores content in blocks which don't move. By definition these are usually larger files, since moving existing blocks is I/O intensive. By carefully choosing signature block size (to match content block size closely) and using block match mode when generating delta, the user can improve delta processing speed.

Would something like this be worth considering?
