### PR TITLE
Optimize rollsum.c to add char offsets once.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,6 +199,10 @@ add_executable(isprefix_test
     
 add_test(NAME isprefix_test COMMAND isprefix_test)
 
+add_executable(rollsum_test
+    tests/rollsum_test.c src/rollsum.c)
+add_test(NAME rollsum_test COMMAND rollsum_test)
+
 # Disable rdiff specific tests
 if (BUILD_RDIFF)
     add_test(NAME rdiff_bad_option

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,7 +229,7 @@ else (BUILD_RDIFF)
   set(LAST_TARGET rsync)
 endif (BUILD_RDIFF)
 add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
-add_dependencies(check ${LAST_TARGET} isprefix_test)
+add_dependencies(check ${LAST_TARGET} isprefix_test rollsum_test)
 
 
 enable_testing()

--- a/src/rollsum.c
+++ b/src/rollsum.c
@@ -27,9 +27,10 @@
 #define DO8(buf,i)  DO4(buf,i); DO4(buf,i+4);
 #define DO16(buf)   DO8(buf,0); DO8(buf,8);
 
-void RollsumUpdate(Rollsum *sum, const unsigned char *buf, size_t len) {
+void RollsumUpdate(Rollsum *sum, const unsigned char *buf, size_t len)
+{
     /* ANSI C says no overflow for unsigned. zlib's adler32 goes to extra
-    effort to avoid overflow for its mod prime, which we don't have.*/
+       effort to avoid overflow for its mod prime, which we don't have. */
     size_t n = len;
     uint_fast16_t s1 = sum->s1;
     uint_fast16_t s2 = sum->s2;
@@ -46,8 +47,8 @@ void RollsumUpdate(Rollsum *sum, const unsigned char *buf, size_t len) {
     }
     /* Increment s1 and s2 by the amounts added by the char offset. */
     s1 += len * ROLLSUM_CHAR_OFFSET;
-    s2 += ((len*(len+1))/2) * ROLLSUM_CHAR_OFFSET;
-    sum->count+=len;  /* Increment sum count. */
-    sum->s1=s1;
-    sum->s2=s2;
+    s2 += ((len * (len + 1)) / 2) * ROLLSUM_CHAR_OFFSET;
+    sum->count += len;          /* Increment sum count. */
+    sum->s1 = s1;
+    sum->s2 = s2;
 }

--- a/src/rollsum.c
+++ b/src/rollsum.c
@@ -27,12 +27,12 @@
 #define DO8(buf,i)  DO4(buf,i); DO4(buf,i+4);
 #define DO16(buf)   DO8(buf,0); DO8(buf,8);
 
-void RollsumUpdate(Rollsum *sum,const unsigned char *buf,unsigned int len) {
+void RollsumUpdate(Rollsum *sum, const unsigned char *buf, size_t len) {
     /* ANSI C says no overflow for unsigned. zlib's adler32 goes to extra
     effort to avoid overflow for its mod prime, which we don't have.*/
-    unsigned int n = len;
-    unsigned long s1 = sum->s1;
-    unsigned long s2 = sum->s2;
+    size_t n = len;
+    uint_fast16_t s1 = sum->s1;
+    uint_fast16_t s2 = sum->s2;
 
     while (n >= 16) {
         DO16(buf);

--- a/src/rollsum.c
+++ b/src/rollsum.c
@@ -26,26 +26,28 @@
 #define DO4(buf,i)  DO2(buf,i); DO2(buf,i+2);
 #define DO8(buf,i)  DO4(buf,i); DO4(buf,i+4);
 #define DO16(buf)   DO8(buf,0); DO8(buf,8);
-#define OF16(off)  {s1 += 16*off; s2 += 136*off;}
 
 void RollsumUpdate(Rollsum *sum,const unsigned char *buf,unsigned int len) {
-    /* ANSI C says no overflow for unsigned. 
-     zlib's adler 32 goes to extra effort to avoid overflow*/
+    /* ANSI C says no overflow for unsigned. zlib's adler32 goes to extra
+    effort to avoid overflow for its mod prime, which we don't have.*/
+    unsigned int n = len;
     unsigned long s1 = sum->s1;
     unsigned long s2 = sum->s2;
 
-    sum->count+=len;                   /* increment sum count */
     while (len >= 16) {
         DO16(buf);
-        OF16(ROLLSUM_CHAR_OFFSET);
         buf += 16;
         len -= 16;
     }
     while (len != 0) {
-        s1 += (*buf++ + ROLLSUM_CHAR_OFFSET);
+        s1 += *buf++;
         s2 += s1;
         len--;
     }
+    /* Increment s1 and s2 by the amounts added by the char offset. */
+    s1 += n * ROLLSUM_CHAR_OFFSET;
+    s2 += ((n*(n+1))>>1) * ROLLSUM_CHAR_OFFSET;
+    sum->count+=n;                   /* Increment sum count. */
     sum->s1=s1;
     sum->s2=s2;
 }

--- a/src/rollsum.c
+++ b/src/rollsum.c
@@ -1,20 +1,20 @@
 /*= -*- c-basic-offset: 4; indent-tabs-mode: nil; -*-
  *
  * rollsum -- the librsync rolling checksum
- * 
- * Copyright (C) 2003 by Donovan Baarda <abo@minkirri.apana.org.au> 
+ *
+ * Copyright (C) 2003 by Donovan Baarda <abo@minkirri.apana.org.au>
  * based on work, Copyright (C) 2000, 2001 by Martin Pool <mbp@sourcefrog.net>
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation; either version 2.1 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
@@ -34,20 +34,20 @@ void RollsumUpdate(Rollsum *sum,const unsigned char *buf,unsigned int len) {
     unsigned long s1 = sum->s1;
     unsigned long s2 = sum->s2;
 
-    while (len >= 16) {
+    while (n >= 16) {
         DO16(buf);
         buf += 16;
-        len -= 16;
+        n -= 16;
     }
-    while (len != 0) {
+    while (n != 0) {
         s1 += *buf++;
         s2 += s1;
-        len--;
+        n--;
     }
     /* Increment s1 and s2 by the amounts added by the char offset. */
-    s1 += n * ROLLSUM_CHAR_OFFSET;
-    s2 += ((n*(n+1))>>1) * ROLLSUM_CHAR_OFFSET;
-    sum->count+=n;                   /* Increment sum count. */
+    s1 += len * ROLLSUM_CHAR_OFFSET;
+    s2 += ((len*(len+1))/2) * ROLLSUM_CHAR_OFFSET;
+    sum->count+=len;  /* Increment sum count. */
     sum->s1=s1;
     sum->s2=s2;
 }

--- a/src/rollsum.h
+++ b/src/rollsum.h
@@ -33,9 +33,9 @@
 
 /** \private */
 typedef struct _Rollsum {
-    size_t count;      /* count of bytes included in sum */
-    uint_fast16_t s1;  /* s1 part of sum */
-    uint_fast16_t s2;  /* s2 part of sum */
+    size_t count;               /* count of bytes included in sum */
+    uint_fast16_t s1;           /* s1 part of sum */
+    uint_fast16_t s2;           /* s2 part of sum */
 } Rollsum;
 
 void RollsumUpdate(Rollsum *sum, const unsigned char *buf, size_t len);
@@ -49,7 +49,7 @@ static inline void RollsumInit(Rollsum *sum)
 static inline void RollsumRotate(Rollsum *sum, unsigned char out, unsigned char in)
 {
     sum->s1 += in - out;
-    sum->s2 += sum->s1 - sum->count*(out + ROLLSUM_CHAR_OFFSET);
+    sum->s2 += sum->s1 - sum->count * (out + ROLLSUM_CHAR_OFFSET);
 }
 
 static inline void RollsumRollin(Rollsum *sum, unsigned char in)
@@ -62,7 +62,7 @@ static inline void RollsumRollin(Rollsum *sum, unsigned char in)
 static inline void RollsumRollout(Rollsum *sum, unsigned char out)
 {
     sum->s1 -= out + ROLLSUM_CHAR_OFFSET;
-    sum->s2 -= sum->count*(out + ROLLSUM_CHAR_OFFSET);
+    sum->s2 -= sum->count * (out + ROLLSUM_CHAR_OFFSET);
     sum->count--;
 }
 
@@ -71,4 +71,4 @@ static inline uint32_t RollsumDigest(Rollsum *sum)
     return ((uint32_t)sum->s2 << 16) | ((uint32_t)sum->s1 & 0xffff);
 }
 
-#endif /* _ROLLSUM_H_ */
+#endif                          /* _ROLLSUM_H_ */

--- a/src/rollsum.h
+++ b/src/rollsum.h
@@ -22,6 +22,9 @@
 #ifndef _ROLLSUM_H_
 #define _ROLLSUM_H_
 
+#include <stddef.h>
+#include <stdint.h>
+
 /* We should make this something other than zero to improve the
  * checksum algorithm: tridge suggests a prime number. */
 #define ROLLSUM_CHAR_OFFSET 31
@@ -30,42 +33,42 @@
 
 /** \private */
 typedef struct _Rollsum {
-    unsigned long count;               /* count of bytes included in sum */
-    unsigned long s1;                  /* s1 part of sum */
-    unsigned long s2;                  /* s2 part of sum */
+    size_t count;      /* count of bytes included in sum */
+    uint_fast16_t s1;  /* s1 part of sum */
+    uint_fast16_t s2;  /* s2 part of sum */
 } Rollsum;
 
-void RollsumUpdate(Rollsum *sum,const unsigned char *buf,unsigned int len);
-/* The following are implemented as macros.
-void RollsumInit(Rollsum *sum);
-void RollsumRotate(Rollsum *sum,unsigned char out, unsigned char in);
-void RollsumRollin(Rollsum *sum,unsigned char c);
-void RollsumRollout(Rollsum *sum,unsigned char c);
-unsigned long RollsumDigest(Rollsum *sum);
-*/
+void RollsumUpdate(Rollsum *sum, const unsigned char *buf, size_t len);
 
-/* macro implementations of simple routines */
-#define RollsumInit(sum) { \
-    (sum)->count=(sum)->s1=(sum)->s2=0; \
+/* static inline implementations of simple routines */
+static inline void RollsumInit(Rollsum *sum)
+{
+    sum->count = sum->s1 = sum->s2 = 0;
 }
 
-#define RollsumRotate(sum,out,in) { \
-    (sum)->s1 += (unsigned char)(in) - (unsigned char)(out); \
-    (sum)->s2 += (sum)->s1 - (sum)->count*((unsigned char)(out)+ROLLSUM_CHAR_OFFSET); \
+static inline void RollsumRotate(Rollsum *sum, unsigned char out, unsigned char in)
+{
+    sum->s1 += in - out;
+    sum->s2 += sum->s1 - sum->count*(out + ROLLSUM_CHAR_OFFSET);
 }
 
-#define RollsumRollin(sum,c) { \
-    (sum)->s1 += ((unsigned char)(c)+ROLLSUM_CHAR_OFFSET); \
-    (sum)->s2 += (sum)->s1; \
-    (sum)->count++; \
+static inline void RollsumRollin(Rollsum *sum, unsigned char in)
+{
+    sum->s1 += in + ROLLSUM_CHAR_OFFSET;
+    sum->s2 += sum->s1;
+    sum->count++;
 }
 
-#define RollsumRollout(sum,c) { \
-    (sum)->s1 -= ((unsigned char)(c)+ROLLSUM_CHAR_OFFSET); \
-    (sum)->s2 -= (sum)->count*((unsigned char)(c)+ROLLSUM_CHAR_OFFSET); \
-    (sum)->count--; \
+static inline void RollsumRollout(Rollsum *sum, unsigned char out)
+{
+    sum->s1 -= out + ROLLSUM_CHAR_OFFSET;
+    sum->s2 -= sum->count*(out + ROLLSUM_CHAR_OFFSET);
+    sum->count--;
 }
 
-#define RollsumDigest(sum) (((sum)->s2 << 16) | ((sum)->s1 & 0xffff))
+static inline uint32_t RollsumDigest(Rollsum *sum)
+{
+    return ((uint32_t)sum->s2 << 16) | ((uint32_t)sum->s1 & 0xffff);
+}
 
 #endif /* _ROLLSUM_H_ */

--- a/tests/rollsum_test.c
+++ b/tests/rollsum_test.c
@@ -41,37 +41,37 @@ int main(int argc, char **argv)
     assert(RollsumDigest(&r) == 0x00000000);
 
     /* Test RollsumRollin() */
-    RollsumRollin(&r, 0);  /* [0] */
+    RollsumRollin(&r, 0);       /* [0] */
     assert(r.count == 1);
     assert(RollsumDigest(&r) == 0x001f001f);
     RollsumRollin(&r, 1);
     RollsumRollin(&r, 2);
-    RollsumRollin(&r, 3);  /* [0,1,2,3] */
+    RollsumRollin(&r, 3);       /* [0,1,2,3] */
     assert(r.count == 4);
     assert(RollsumDigest(&r) == 0x01400082);
 
     /* Test RollsumRotate() */
-    RollsumRotate(&r,0,4);  /* [1,2,3,4] */
+    RollsumRotate(&r, 0, 4);    /* [1,2,3,4] */
     assert(r.count == 4);
     assert(RollsumDigest(&r) == 0x014a0086);
-    RollsumRotate(&r,1,5);
-    RollsumRotate(&r,2,6);
-    RollsumRotate(&r,3,7);  /* [4,5,6,7] */
+    RollsumRotate(&r, 1, 5);
+    RollsumRotate(&r, 2, 6);
+    RollsumRotate(&r, 3, 7);    /* [4,5,6,7] */
     assert(r.count == 4);
     assert(RollsumDigest(&r) == 0x01680092);
 
     /* Test RollsumRollout() */
-    RollsumRollout(&r, 4);  /* [5,6,7] */
+    RollsumRollout(&r, 4);      /* [5,6,7] */
     assert(r.count == 3);
     assert(RollsumDigest(&r) == 0x00dc006f);
     RollsumRollout(&r, 5);
     RollsumRollout(&r, 6);
-    RollsumRollout(&r, 7); /* [] */
+    RollsumRollout(&r, 7);      /* [] */
     assert(r.count == 0);
     assert(RollsumDigest(&r) == 0x00000000);
 
     /* Test RollsumUpdate() */
-    for (i=0; i < 256; i++)
+    for (i = 0; i < 256; i++)
         buf[i] = i;
     RollsumUpdate(&r, buf, 256);
     assert(RollsumDigest(&r) == 0x3a009e80);

--- a/tests/rollsum_test.c
+++ b/tests/rollsum_test.c
@@ -30,6 +30,7 @@
 int main(int argc, char **argv)
 {
     Rollsum r;
+    int i;
     unsigned char buf[256];
 
     /* Test RollsumInit() */
@@ -70,7 +71,7 @@ int main(int argc, char **argv)
     assert(RollsumDigest(&r) == 0x00000000);
 
     /* Test RollsumUpdate() */
-    for (int i=0; i < 256; i++)
+    for (i=0; i < 256; i++)
         buf[i] = i;
     RollsumUpdate(&r, buf, 256);
     assert((uint32_t)RollsumDigest(&r) == 0x3a009e80);

--- a/tests/rollsum_test.c
+++ b/tests/rollsum_test.c
@@ -74,6 +74,6 @@ int main(int argc, char **argv)
     for (i=0; i < 256; i++)
         buf[i] = i;
     RollsumUpdate(&r, buf, 256);
-    assert((uint32_t)RollsumDigest(&r) == 0x3a009e80);
+    assert(RollsumDigest(&r) == 0x3a009e80);
     return 0;
 }

--- a/tests/rollsum_test.c
+++ b/tests/rollsum_test.c
@@ -1,0 +1,78 @@
+/*= -*- c-basic-offset: 4; indent-tabs-mode: nil; -*-
+ *
+ * rollsum_test -- tests for the librsync rolling checksum.
+ *
+ * Copyright (C) 2003 by Donovan Baarda <abo@minkirri.apana.org.au>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <assert.h>
+#include "rollsum.h"
+
+/*
+ * Test driver for rollsum.
+ */
+int main(int argc, char **argv)
+{
+    Rollsum r;
+    unsigned char buf[256];
+
+    /* Test RollsumInit() */
+    RollsumInit(&r);
+    assert(r.count == 0);
+    assert(r.s1 == 0);
+    assert(r.s2 == 0);
+    assert(RollsumDigest(&r) == 0x00000000);
+
+    /* Test RollsumRollin() */
+    RollsumRollin(&r, 0);  /* [0] */
+    assert(r.count == 1);
+    assert(RollsumDigest(&r) == 0x001f001f);
+    RollsumRollin(&r, 1);
+    RollsumRollin(&r, 2);
+    RollsumRollin(&r, 3);  /* [0,1,2,3] */
+    assert(r.count == 4);
+    assert(RollsumDigest(&r) == 0x01400082);
+
+    /* Test RollsumRotate() */
+    RollsumRotate(&r,0,4);  /* [1,2,3,4] */
+    assert(r.count == 4);
+    assert(RollsumDigest(&r) == 0x014a0086);
+    RollsumRotate(&r,1,5);
+    RollsumRotate(&r,2,6);
+    RollsumRotate(&r,3,7);  /* [4,5,6,7] */
+    assert(r.count == 4);
+    assert(RollsumDigest(&r) == 0x01680092);
+
+    /* Test RollsumRollout() */
+    RollsumRollout(&r, 4);  /* [5,6,7] */
+    assert(r.count == 3);
+    assert(RollsumDigest(&r) == 0x00dc006f);
+    RollsumRollout(&r, 5);
+    RollsumRollout(&r, 6);
+    RollsumRollout(&r, 7); /* [] */
+    assert(r.count == 0);
+    assert(RollsumDigest(&r) == 0x00000000);
+
+    /* Test RollsumUpdate() */
+    for (int i=0; i < 256; i++)
+        buf[i] = i;
+    RollsumUpdate(&r, buf, 256);
+    assert((uint32_t)RollsumDigest(&r) == 0x3a009e80);
+    return 0;
+}


### PR DESCRIPTION
The char offsets in the rollsum don't need to be added incrementally, but can be calculated and added once.