### PR TITLE
Tidy rs_weak_sum_t related code.

### DIFF
--- a/src/checksum.h
+++ b/src/checksum.h
@@ -1,30 +1,25 @@
 /*= -*- c-basic-offset: 4; indent-tabs-mode: nil; -*-
  *
  * librsync -- the library for network deltas
- * 
+ *
  * Copyright (C) 2000, 2001 by Martin Pool <mbp@sourcefrog.net>
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation; either version 2.1 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-rs_weak_sum_t rs_calc_weak_sum(void const *buf1, int len);
+rs_weak_sum_t rs_calc_weak_sum(void const *buf, size_t len);
 
 void rs_calc_md4_sum(void const *buf, size_t buf_len, rs_strong_sum_t *);
 void rs_calc_blake2_sum(void const *buf, size_t buf_len, rs_strong_sum_t *);
-
-/* We should make this something other than zero to improve the
- * checksum algorithm: tridge suggests a prime number. */
-#define RS_CHAR_OFFSET 31
-

--- a/src/librsync.h
+++ b/src/librsync.h
@@ -37,6 +37,7 @@
 #define _RSYNC_H
 
 #include <sys/types.h>
+#include "types.h"
 #include "librsync-config.h"
 
 #ifdef __cplusplus
@@ -269,7 +270,7 @@ extern const int RS_MD4_SUM_LENGTH, RS_BLAKE2_SUM_LENGTH;
 
 #define RS_MAX_STRONG_SUM_LENGTH 32
 
-typedef unsigned int rs_weak_sum_t;
+typedef uint32_t rs_weak_sum_t;
 typedef unsigned char rs_strong_sum_t[RS_MAX_STRONG_SUM_LENGTH];
 
 void            rs_mdfour(unsigned char *out, void const *in, size_t);

--- a/src/mksum.c
+++ b/src/mksum.c
@@ -24,7 +24,7 @@
 /**
  * \file mksum.c Generate file signatures.
  **/
- 
+
 /*
  * Generating checksums is pretty easy, since we can always just
  * process whatever data is available.  When a whole block has
@@ -58,7 +58,7 @@ static rs_result rs_sig_s_header(rs_job_t *);
 static rs_result rs_sig_s_generate(rs_job_t *);
 
 
-                                           
+
 /**
  * State of trying to send the signature header.
  * \private
@@ -71,7 +71,7 @@ static rs_result rs_sig_s_header(rs_job_t *job)
     rs_trace("sent header (magic %#x, block len = %d, strong sum len = %d)",
              job->magic, (int) job->block_len, (int) job->strong_sum_len);
     job->stats.block_len = job->block_len;
-    
+
     job->statefn = rs_sig_s_generate;
     return RS_RUNNING;
 }
@@ -85,7 +85,7 @@ static rs_result rs_sig_s_header(rs_job_t *job)
 static rs_result
 rs_sig_do_block(rs_job_t *job, const void *block, size_t len)
 {
-    unsigned int        weak_sum;
+    rs_weak_sum_t       weak_sum;
     rs_strong_sum_t     strong_sum;
 
     weak_sum = rs_calc_weak_sum(block, len);
@@ -125,11 +125,11 @@ rs_sig_s_generate(rs_job_t *job)
     rs_result           result;
     size_t              len;
     void                *block;
-        
+
     /* must get a whole block, otherwise try again */
     len = job->block_len;
     result = rs_scoop_read(job, len, &block);
-        
+
     /* unless we're near eof, in which case we'll accept
      * whatever's in there */
     if ((result == RS_BLOCKED && rs_job_input_is_ending(job))) {


### PR DESCRIPTION
In checksum.c make rs_calc_weak_sum() use the implementation in
rollsum.[hc]. Tidy checksum.h removing now unused RS_CHAR_OFFSET.

In librsync.h change rs_weak_sum_t from "unsigned int" to uint32_t.

In mksum.c use rs_weak_sum_t instead of "unsigned int" as the type of
a calculated weaksum.