### PR TITLE
Tidy signature handling code.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,12 +32,13 @@ Testing
 # Editor temp files
 .sw?
 .*.sw?
+*~
 
 # OSX build outputs
 *.dSYM
 
 # Test binaries
-isprefix_test
+*_test
 
 *.bak
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,21 +198,25 @@ execute_process(COMMAND ${PERL_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/src/mkpr
 
 add_executable(isprefix_test
     tests/isprefix_test.c src/isprefix.c)
-    
+
 add_test(NAME isprefix_test COMMAND isprefix_test)
 
 add_executable(rollsum_test
     tests/rollsum_test.c src/rollsum.c)
 add_test(NAME rollsum_test COMMAND rollsum_test)
 
+add_executable(sumset_test
+    tests/sumset_test.c src/sumset.c src/util.c src/trace.c src/hex.c src/checksum.c src/rollsum.c src/mdfour.c src/blake2b-ref.c)
+add_test(NAME sumset_test COMMAND sumset_test)
+
 # Disable rdiff specific tests
 if (BUILD_RDIFF)
     add_test(NAME rdiff_bad_option
              COMMAND rdiff_bad_option.sh ${CMAKE_CURRENT_BINARY_DIR}
              WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-    
+
     add_test(NAME Help COMMAND help.test ${CMAKE_CURRENT_BINARY_DIR} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-    
+
     add_test(NAME Mutate COMMAND mutate.test ${CMAKE_CURRENT_BINARY_DIR} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
     add_test(NAME Signature COMMAND signature.test ${CMAKE_CURRENT_BINARY_DIR} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
     add_test(NAME Sources COMMAND sources.test ${CMAKE_CURRENT_BINARY_DIR} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
@@ -231,7 +235,7 @@ else (BUILD_RDIFF)
   set(LAST_TARGET rsync)
 endif (BUILD_RDIFF)
 add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
-add_dependencies(check ${LAST_TARGET} isprefix_test rollsum_test)
+add_dependencies(check ${LAST_TARGET} isprefix_test rollsum_test sumset_test)
 
 
 enable_testing()

--- a/src/delta.c
+++ b/src/delta.c
@@ -79,9 +79,6 @@
 #include "types.h"
 #include "rollsum.h"
 
-const int RS_MD4_SUM_LENGTH = 16;
-const int RS_BLAKE2_SUM_LENGTH = 32;
-
 /**
  * 2002-06-26: Donovan Baarda
  *

--- a/src/delta.c
+++ b/src/delta.c
@@ -21,10 +21,11 @@
  */
 
                                 /*
-                                   | Let's climb to the TOP of that
-                                   | MOUNTAIN and think about STRIP
-                                   | MINING!!
+                                 | Let's climb to the TOP of that
+                                 | MOUNTAIN and think about STRIP
+                                 | MINING!!
                                  */
+
 
 /*
  * delta.c -- Generate in streaming mode an rsync delta given a set of
@@ -59,6 +60,7 @@
  *
  * If nothing matches, it is not so good.
  */
+
 
 #include "config.h"
 
@@ -138,43 +140,47 @@ static inline rs_result rs_processmiss(rs_job_t *job);
  * scoop and input buffer. */
 static rs_result rs_delta_s_scan(rs_job_t *job)
 {
-    rs_long_t match_pos;
-    size_t match_len;
-    rs_result result;
-    Rollsum test;
+    rs_long_t      match_pos;
+    size_t         match_len;
+    rs_result      result;
+    Rollsum        test;
 
     rs_job_check(job);
     /* read the input into the scoop */
     rs_getinput(job);
     /* output any pending output from the tube */
-    result = rs_tube_catchup(job);
+    result=rs_tube_catchup(job);
     /* while output is not blocked and there is a block of data */
-    while ((result == RS_DONE) && ((job->scoop_pos + job->block_len) < job->scoop_avail)) {
+    while ((result==RS_DONE) &&
+           ((job->scoop_pos + job->block_len) < job->scoop_avail)) {
         /* check if this block matches */
-        if (rs_findmatch(job, &match_pos, &match_len)) {
+        if (rs_findmatch(job,&match_pos,&match_len)) {
             /* append the match and reset the weak_sum */
-            result = rs_appendmatch(job, match_pos, match_len);
+            result=rs_appendmatch(job,match_pos,match_len);
             RollsumInit(&job->weak_sum);
         } else {
             /* rotate the weak_sum and append the miss byte */
-            RollsumRotate(&job->weak_sum, job->scoop_next[job->scoop_pos],
-                          job->scoop_next[job->scoop_pos + job->block_len]);
-            result = rs_appendmiss(job, 1);
+            RollsumRotate(&job->weak_sum,job->scoop_next[job->scoop_pos],
+                          job->scoop_next[job->scoop_pos+job->block_len]);
+            result=rs_appendmiss(job,1);
             if (rs_roll_paranoia) {
                 RollsumInit(&test);
-                RollsumUpdate(&test, job->scoop_next + job->scoop_pos, job->block_len);
+                RollsumUpdate(&test, job->scoop_next+job->scoop_pos,
+                              job->block_len);
                 if (RollsumDigest(&test) != RollsumDigest(&job->weak_sum)) {
-                    rs_fatal("mismatch between rolled sum %#x and check %#x", (int)RollsumDigest(&job->weak_sum),
+                    rs_fatal("mismatch between rolled sum %#x and check %#x",
+                             (int)RollsumDigest(&job->weak_sum),
                              (int)RollsumDigest(&test));
                 }
+                
             }
         }
     }
     /* if we completed OK */
-    if (result == RS_DONE) {
+    if (result==RS_DONE) {
         /* if we reached eof, we can flush the last fragment */
         if (job->stream->eof_in) {
-            job->statefn = rs_delta_s_flush;
+            job->statefn=rs_delta_s_flush;
             return RS_RUNNING;
         } else {
             /* we are blocked waiting for more data */
@@ -184,41 +190,43 @@ static rs_result rs_delta_s_scan(rs_job_t *job)
     return result;
 }
 
+
 static rs_result rs_delta_s_flush(rs_job_t *job)
 {
-    rs_long_t match_pos;
-    size_t match_len;
-    rs_result result;
+    rs_long_t      match_pos;
+    size_t         match_len;
+    rs_result      result;
 
     rs_job_check(job);
     /* read the input into the scoop */
     rs_getinput(job);
     /* output any pending output */
-    result = rs_tube_catchup(job);
+    result=rs_tube_catchup(job);
     /* while output is not blocked and there is any remaining data */
-    while ((result == RS_DONE) && (job->scoop_pos < job->scoop_avail)) {
+    while ((result==RS_DONE) && (job->scoop_pos < job->scoop_avail)) {
         /* check if this block matches */
-        if (rs_findmatch(job, &match_pos, &match_len)) {
+        if (rs_findmatch(job,&match_pos,&match_len)) {
             /* append the match and reset the weak_sum */
-            result = rs_appendmatch(job, match_pos, match_len);
+            result=rs_appendmatch(job,match_pos,match_len);
             RollsumInit(&job->weak_sum);
         } else {
             /* rollout from weak_sum and append the miss byte */
-            RollsumRollout(&job->weak_sum, job->scoop_next[job->scoop_pos]);
+            RollsumRollout(&job->weak_sum,job->scoop_next[job->scoop_pos]);
             rs_trace("block reduced to %d", (int)job->weak_sum.count);
-            result = rs_appendmiss(job, 1);
+            result=rs_appendmiss(job,1);
         }
     }
     /* if we are not blocked, flush and set end statefn. */
-    if (result == RS_DONE) {
-        result = rs_appendflush(job);
-        job->statefn = rs_delta_s_end;
+    if (result==RS_DONE) {
+        result=rs_appendflush(job);
+        job->statefn=rs_delta_s_end;
     }
-    if (result == RS_DONE) {
+    if (result==RS_DONE) {
         return RS_RUNNING;
     }
     return result;
 }
+
 
 static rs_result rs_delta_s_end(rs_job_t *job)
 {
@@ -226,16 +234,17 @@ static rs_result rs_delta_s_end(rs_job_t *job)
     return RS_DONE;
 }
 
-void rs_getinput(rs_job_t *job)
-{
-    size_t len;
 
-    len = rs_scoop_total_avail(job);
+void rs_getinput(rs_job_t *job) {
+    size_t len;
+    
+    len=rs_scoop_total_avail(job);
     if (job->scoop_avail < len) {
-        rs_scoop_input(job, len);
+        rs_scoop_input(job,len);
     }
 }
 
+        
 /**
  * find a match at scoop_pos, returning the match_pos and match_len.
  * Note that this will calculate weak_sum if required. It will also
@@ -246,52 +255,57 @@ void rs_getinput(rs_job_t *job)
  * forwards beyond the block boundaries. Extending backwards would require
  * decrementing scoop_pos as appropriate.
  */
-inline int rs_findmatch(rs_job_t *job, rs_long_t *match_pos, size_t *match_len)
-{
+inline int rs_findmatch(rs_job_t *job, rs_long_t *match_pos, size_t *match_len) {
     /* calculate the weak_sum if we don't have one */
     if (job->weak_sum.count == 0) {
         /* set match_len to min(block_len, scan_avail) */
-        *match_len = job->scoop_avail - job->scoop_pos;
+        *match_len=job->scoop_avail - job->scoop_pos;
         if (*match_len > job->block_len) {
             *match_len = job->block_len;
         }
         /* Update the weak_sum */
-        RollsumUpdate(&job->weak_sum, job->scoop_next + job->scoop_pos, *match_len);
-        rs_trace("calculate weak sum from scratch length %d", (int)job->weak_sum.count);
+        RollsumUpdate(&job->weak_sum,job->scoop_next+job->scoop_pos,*match_len);
+        rs_trace("calculate weak sum from scratch length %d",(int)job->weak_sum.count);
     } else {
         /* set the match_len to the weak_sum count */
-        *match_len = job->weak_sum.count;
+        *match_len=job->weak_sum.count;
     }
-    return rs_search_for_block(RollsumDigest(&job->weak_sum), job->scoop_next + job->scoop_pos, *match_len,
-                               job->signature, &job->stats, match_pos);
+    return rs_search_for_block(RollsumDigest(&job->weak_sum),
+                               job->scoop_next+job->scoop_pos,
+                               *match_len,
+                               job->signature,
+                               &job->stats,
+                               match_pos);
 }
+
 
 /**
  * Append a match at match_pos of length match_len to the delta, extending
  * a previous match if possible, or flushing any previous miss/match. */
 inline rs_result rs_appendmatch(rs_job_t *job, rs_long_t match_pos, size_t match_len)
 {
-    rs_result result = RS_DONE;
-
+    rs_result result=RS_DONE;
+    
     /* if last was a match that can be extended, extend it */
     if (job->basis_len && (job->basis_pos + job->basis_len) == match_pos) {
-        job->basis_len += match_len;
+        job->basis_len+=match_len;
     } else {
         /* else appendflush the last value */
-        result = rs_appendflush(job);
+        result=rs_appendflush(job);
         /* make this the new match value */
-        job->basis_pos = match_pos;
-        job->basis_len = match_len;
+        job->basis_pos=match_pos;
+        job->basis_len=match_len;
     }
     /* increment scoop_pos to point at next unscanned data */
-    job->scoop_pos += match_len;
+    job->scoop_pos+=match_len;
     /* we can only process from the scoop if output is not blocked */
-    if (result == RS_DONE) {
-        /* process the match data off the scoop */
-        result = rs_processmatch(job);
+    if (result==RS_DONE) {
+        /* process the match data off the scoop*/
+        result=rs_processmatch(job);
     }
     return result;
 }
+
 
 /**
  * Append a miss of length miss_len to the delta, extending a previous miss
@@ -301,16 +315,17 @@ inline rs_result rs_appendmatch(rs_job_t *job, rs_long_t match_pos, size_t match
  * too much in memory. */
 inline rs_result rs_appendmiss(rs_job_t *job, size_t miss_len)
 {
-    rs_result result = RS_DONE;
-
+    rs_result result=RS_DONE;
+    
     /* if last was a match, or block_len misses, appendflush it */
     if (job->basis_len || (job->scoop_pos >= rs_outbuflen)) {
-        result = rs_appendflush(job);
+        result=rs_appendflush(job);
     }
     /* increment scoop_pos */
-    job->scoop_pos += miss_len;
+    job->scoop_pos+=miss_len;
     return result;
 }
+
 
 /**
  * Flush any accumulating hit or miss, appending it to the delta.
@@ -319,20 +334,22 @@ inline rs_result rs_appendflush(rs_job_t *job)
 {
     /* if last is a match, emit it and reset last by resetting basis_len */
     if (job->basis_len) {
-        rs_trace("matched " PRINTF_FORMAT_U64 " bytes at " PRINTF_FORMAT_U64 "!", PRINTF_CAST_U64(job->basis_len),
+        rs_trace("matched " PRINTF_FORMAT_U64 " bytes at " PRINTF_FORMAT_U64 "!",
+                 PRINTF_CAST_U64(job->basis_len),
                  PRINTF_CAST_U64(job->basis_pos));
         rs_emit_copy_cmd(job, job->basis_pos, job->basis_len);
-        job->basis_len = 0;
+        job->basis_len=0;
         return rs_processmatch(job);
-        /* else if last is a miss, emit and process it */
+    /* else if last is a miss, emit and process it*/
     } else if (job->scoop_pos) {
-        rs_trace("got %ld bytes of literal data", (long)job->scoop_pos);
+        rs_trace("got %ld bytes of literal data", (long) job->scoop_pos);
         rs_emit_literal_cmd(job, job->scoop_pos);
         return rs_processmiss(job);
     }
     /* otherwise, nothing to flush so we are done */
     return RS_DONE;
 }
+
 
 /**
  * The scoop contains match data at scoop_next of length scoop_pos. This
@@ -346,12 +363,12 @@ inline rs_result rs_appendflush(rs_job_t *job)
  * rs_tube_catchup to output any pending output. */
 inline rs_result rs_processmatch(rs_job_t *job)
 {
-    job->scoop_avail -= job->scoop_pos;
-    job->scoop_next += job->scoop_pos;
-    job->scoop_pos = 0;
+    job->scoop_avail-=job->scoop_pos;
+    job->scoop_next+=job->scoop_pos;
+    job->scoop_pos=0;
     return rs_tube_catchup(job);
 }
-
+    
 /**
  * The scoop contains miss data at scoop_next of length scoop_pos. This
  * function processes that miss data, returning RS_DONE if it completes, or
@@ -369,9 +386,10 @@ inline rs_result rs_processmatch(rs_job_t *job)
 inline rs_result rs_processmiss(rs_job_t *job)
 {
     rs_tube_copy(job, job->scoop_pos);
-    job->scoop_pos = 0;
+    job->scoop_pos=0;
     return rs_tube_catchup(job);
 }
+
 
 /**
  * \brief State function that does a slack delta containing only
@@ -379,11 +397,12 @@ inline rs_result rs_processmiss(rs_job_t *job)
  */
 static rs_result rs_delta_s_slack(rs_job_t *job)
 {
-    rs_buffers_t *const stream = job->stream;
+    rs_buffers_t * const stream = job->stream;
     size_t avail = stream->avail_in;
 
     if (avail) {
-        rs_trace("emit slack delta for " PRINTF_FORMAT_U64 " available bytes", PRINTF_CAST_U64(avail));
+        rs_trace("emit slack delta for " PRINTF_FORMAT_U64
+                 " available bytes", PRINTF_CAST_U64(avail));
         rs_emit_literal_cmd(job, avail);
         rs_tube_copy(job, avail);
         return RS_RUNNING;
@@ -396,6 +415,7 @@ static rs_result rs_delta_s_slack(rs_job_t *job)
         }
     }
 }
+
 
 /**
  * State function for writing out the header of the encoding job.
@@ -411,12 +431,14 @@ static rs_result rs_delta_s_header(rs_job_t *job)
         }
         job->statefn = rs_delta_s_scan;
     } else {
-        rs_trace("block length is zero for this delta; " "therefore using slack deltas");
+        rs_trace("block length is zero for this delta; "
+                 "therefore using slack deltas");
         job->statefn = rs_delta_s_slack;
     }
 
     return RS_RUNNING;
 }
+
 
 rs_job_t *rs_delta_begin(rs_signature_t *sig)
 {

--- a/src/delta.c
+++ b/src/delta.c
@@ -140,6 +140,7 @@ static inline rs_result rs_processmiss(rs_job_t *job);
  * scoop and input buffer. */
 static rs_result rs_delta_s_scan(rs_job_t *job)
 {
+    size_t         block_len = job->signature->block_len;
     rs_long_t      match_pos;
     size_t         match_len;
     rs_result      result;
@@ -152,7 +153,7 @@ static rs_result rs_delta_s_scan(rs_job_t *job)
     result=rs_tube_catchup(job);
     /* while output is not blocked and there is a block of data */
     while ((result==RS_DONE) &&
-           ((job->scoop_pos + job->block_len) < job->scoop_avail)) {
+           ((job->scoop_pos + block_len) < job->scoop_avail)) {
         /* check if this block matches */
         if (rs_findmatch(job,&match_pos,&match_len)) {
             /* append the match and reset the weak_sum */
@@ -160,19 +161,18 @@ static rs_result rs_delta_s_scan(rs_job_t *job)
             RollsumInit(&job->weak_sum);
         } else {
             /* rotate the weak_sum and append the miss byte */
-            RollsumRotate(&job->weak_sum,job->scoop_next[job->scoop_pos],
-                          job->scoop_next[job->scoop_pos+job->block_len]);
+            RollsumRotate(&job->weak_sum, job->scoop_next[job->scoop_pos],
+                          job->scoop_next[job->scoop_pos + block_len]);
             result=rs_appendmiss(job,1);
             if (rs_roll_paranoia) {
                 RollsumInit(&test);
-                RollsumUpdate(&test, job->scoop_next+job->scoop_pos,
-                              job->block_len);
+                RollsumUpdate(&test, job->scoop_next + job->scoop_pos, block_len);
                 if (RollsumDigest(&test) != RollsumDigest(&job->weak_sum)) {
                     rs_fatal("mismatch between rolled sum %#x and check %#x",
                              (int)RollsumDigest(&job->weak_sum),
                              (int)RollsumDigest(&test));
                 }
-                
+
             }
         }
     }
@@ -237,14 +237,14 @@ static rs_result rs_delta_s_end(rs_job_t *job)
 
 void rs_getinput(rs_job_t *job) {
     size_t len;
-    
+
     len=rs_scoop_total_avail(job);
     if (job->scoop_avail < len) {
         rs_scoop_input(job,len);
     }
 }
 
-        
+
 /**
  * find a match at scoop_pos, returning the match_pos and match_len.
  * Note that this will calculate weak_sum if required. It will also
@@ -256,12 +256,14 @@ void rs_getinput(rs_job_t *job) {
  * decrementing scoop_pos as appropriate.
  */
 inline int rs_findmatch(rs_job_t *job, rs_long_t *match_pos, size_t *match_len) {
+    size_t block_len = job->signature->block_len;
+
     /* calculate the weak_sum if we don't have one */
     if (job->weak_sum.count == 0) {
         /* set match_len to min(block_len, scan_avail) */
         *match_len=job->scoop_avail - job->scoop_pos;
-        if (*match_len > job->block_len) {
-            *match_len = job->block_len;
+        if (*match_len > block_len) {
+            *match_len = block_len;
         }
         /* Update the weak_sum */
         RollsumUpdate(&job->weak_sum,job->scoop_next+job->scoop_pos,*match_len);
@@ -285,7 +287,7 @@ inline int rs_findmatch(rs_job_t *job, rs_long_t *match_pos, size_t *match_len) 
 inline rs_result rs_appendmatch(rs_job_t *job, rs_long_t match_pos, size_t match_len)
 {
     rs_result result=RS_DONE;
-    
+
     /* if last was a match that can be extended, extend it */
     if (job->basis_len && (job->basis_pos + job->basis_len) == match_pos) {
         job->basis_len+=match_len;
@@ -311,13 +313,13 @@ inline rs_result rs_appendmatch(rs_job_t *job, rs_long_t match_pos, size_t match
  * Append a miss of length miss_len to the delta, extending a previous miss
  * if possible, or flushing any previous match.
  *
- * This also breaks misses up into block_len segments to avoid accumulating
+ * This also breaks misses up into rs_outbuflen segments to avoid accumulating
  * too much in memory. */
 inline rs_result rs_appendmiss(rs_job_t *job, size_t miss_len)
 {
     rs_result result=RS_DONE;
-    
-    /* if last was a match, or block_len misses, appendflush it */
+
+    /* If last was a match, or rs_outbuflen misses, appendflush it. */
     if (job->basis_len || (job->scoop_pos >= rs_outbuflen)) {
         result=rs_appendflush(job);
     }
@@ -368,7 +370,7 @@ inline rs_result rs_processmatch(rs_job_t *job)
     job->scoop_pos=0;
     return rs_tube_catchup(job);
 }
-    
+
 /**
  * The scoop contains miss data at scoop_next of length scoop_pos. This
  * function processes that miss data, returning RS_DONE if it completes, or
@@ -406,14 +408,11 @@ static rs_result rs_delta_s_slack(rs_job_t *job)
         rs_emit_literal_cmd(job, avail);
         rs_tube_copy(job, avail);
         return RS_RUNNING;
-    } else {
-        if (rs_job_input_is_ending(job)) {
-            job->statefn = rs_delta_s_end;
-            return RS_RUNNING;
-        } else {
-            return RS_BLOCKED;
-        }
+    } else if (rs_job_input_is_ending(job)) {
+        job->statefn = rs_delta_s_end;
+        return RS_RUNNING;
     }
+    return RS_BLOCKED;
 }
 
 
@@ -423,19 +422,12 @@ static rs_result rs_delta_s_slack(rs_job_t *job)
 static rs_result rs_delta_s_header(rs_job_t *job)
 {
     rs_emit_delta_header(job);
-
-    if (job->block_len) {
-        if (!job->signature) {
-            rs_error("no signature is loaded into the job");
-            return RS_PARAM_ERROR;
-        }
+    if (job->signature) {
         job->statefn = rs_delta_s_scan;
     } else {
-        rs_trace("block length is zero for this delta; "
-                 "therefore using slack deltas");
+        rs_trace("no signature provided for delta, using slack deltas");
         job->statefn = rs_delta_s_slack;
     }
-
     return RS_RUNNING;
 }
 
@@ -451,8 +443,6 @@ rs_job_t *rs_delta_begin(rs_signature_t *sig)
         /* Caller must have called rs_build_hash_table() by now. */
         assert(sig->tag_table);
         job->signature = sig;
-        job->block_len = sig->block_len;
-        job->strong_sum_len = sig->strong_sum_len;
         RollsumInit(&job->weak_sum);
     }
     return job;

--- a/src/delta.c
+++ b/src/delta.c
@@ -137,7 +137,7 @@ static inline rs_result rs_processmiss(rs_job_t *job);
  * scoop and input buffer. */
 static rs_result rs_delta_s_scan(rs_job_t *job)
 {
-    size_t         block_len = job->signature->block_len;
+    const size_t   block_len = job->signature->block_len;
     rs_long_t      match_pos;
     size_t         match_len;
     rs_result      result;
@@ -253,7 +253,7 @@ void rs_getinput(rs_job_t *job) {
  * decrementing scoop_pos as appropriate.
  */
 inline int rs_findmatch(rs_job_t *job, rs_long_t *match_pos, size_t *match_len) {
-    size_t block_len = job->signature->block_len;
+    const size_t block_len = job->signature->block_len;
 
     /* calculate the weak_sum if we don't have one */
     if (job->weak_sum.count == 0) {

--- a/src/job.c
+++ b/src/job.c
@@ -91,7 +91,7 @@ rs_result rs_job_free(rs_job_t *job)
 {
     free(job->scoop_buf);
     if (job->job_owns_sig)
-	  rs_free_sumset(job->sig);
+	  rs_free_sumset(job->signature);
     rs_bzero(job, sizeof *job);
     free(job);
 

--- a/src/job.c
+++ b/src/job.c
@@ -89,9 +89,9 @@ void rs_job_check(rs_job_t *job)
 
 rs_result rs_job_free(rs_job_t *job)
 {
-    if (job->scoop_buf)
-            free(job->scoop_buf);
-
+    free(job->scoop_buf);
+    if (job->job_owns_sig)
+	  rs_free_sumset(job->sig);
     rs_bzero(job, sizeof *job);
     free(job);
 

--- a/src/job.h
+++ b/src/job.h
@@ -40,23 +40,21 @@ struct rs_job {
     /** Final result of processing job.  Used by rs_job_s_failed(). */
     rs_result final_result;
 
-    /* XXX: These are redundant with their equivalents in the signature field.
-     * Perhaps we could get rid of them, but they are currently used in many
-     * places, including as temporary storage before a signature is
-     * initialized in mksum.c and readsums.c. */
-    int                 magic;
-    int                 block_len;
-    int                 strong_sum_len;
+    /* Arguments for initializing the signature used by mksum.c and
+     * readsums.c. */
+    int                 sig_magic;
+    int                 sig_block_len;
+    int                 sig_strong_len;
+
+    /** The size of the signature file if available. Used by loadsums.c
+     * when initializing the signature to preallocate memory. */
+    rs_long_t           sig_fsize;
 
     /** Pointer to the signature that's being used by the operation. */
     rs_signature_t      *signature;
 
     /** Flag indicating signature should be destroyed with the job. */
     int                 job_owns_sig;
-
-    /** The length of signature file in bytes, if available.
-     * Used by loadsums.c for preallocating memory for signatures. */
-    rs_long_t           sig_fsize;
 
     /** Command byte currently being processed, if any. */
     unsigned char       op;

--- a/src/job.h
+++ b/src/job.h
@@ -54,9 +54,9 @@ struct rs_job {
     /** Flag indicating signature should be destroyed with the job. */
     int                 job_owns_sig;
 
-    /** The length of signature file in bytes, if available;
-     * used for preallocating needed memory for sums */
-    rs_long_t           sig_file_bytes;
+    /** The length of signature file in bytes, if available.
+     * Used by loadsums.c for preallocating memory for signatures. */
+    rs_long_t           sig_fsize;
 
     /** Command byte currently being processed, if any. */
     unsigned char       op;

--- a/src/job.h
+++ b/src/job.h
@@ -31,7 +31,7 @@ struct rs_job {
 
     /** Human-readable job operation name. */
     const char          *job_name;
-    
+
     rs_buffers_t *stream;
 
     /** Callback for each processing step. */
@@ -40,15 +40,19 @@ struct rs_job {
     /** Final result of processing job.  Used by rs_job_s_failed(). */
     rs_result final_result;
 
-    /* XXX: These next two are redundant with their equivalents in the
-     * signature field.  Perhaps we should get rid of them, but
-     * they're also used in the mksum operation. */
+    /* XXX: These are redundant with their equivalents in the signature field.
+     * Perhaps we could get rid of them, but they are currently used in many
+     * places, including as temporary storage before a signature is
+     * initialized in mksum.c and readsums.c. */
+    int                 magic;
     int                 block_len;
     int                 strong_sum_len;
 
-    /** Signature that's either being read in, or used for
-     * generating a delta. */
+    /** Pointer to the signature that's being used by the operation. */
     rs_signature_t      *signature;
+
+    /** Flag indicating signature should be destroyed with the job. */
+    int                 job_owns_sig;
 
     /** The length of signature file in bytes, if available;
      * used for preallocating needed memory for sums */
@@ -59,13 +63,13 @@ struct rs_job {
 
     /** The weak signature digest used by readsums.c */
     rs_weak_sum_t       weak_sig;
-    
+
     /** The rollsum weak signature accumulator used by delta.c */
     Rollsum             weak_sum;
 
     /** Lengths of expected parameters. */
     rs_long_t           param1, param2;
-    
+
     struct rs_prototab_ent const *cmd;
     rs_mdfour_t      output_md4;
 
@@ -82,7 +86,7 @@ struct rs_job {
     size_t      scoop_alloc;           /* the allocation size */
     size_t      scoop_avail;           /* the data size */
     size_t      scoop_pos;             /* the scan position */
-        
+
     /** If USED is >0, then buf contains that much write data to
      * be sent out. */
     rs_byte_t   write_buf[36];
@@ -99,7 +103,6 @@ struct rs_job {
     rs_copy_cb      *copy_cb;
     void            *copy_arg;
 
-    int             magic;
 };
 
 

--- a/src/job.h
+++ b/src/job.h
@@ -54,9 +54,6 @@ struct rs_job {
      * used for preallocating needed memory for sums */
     rs_long_t           sig_file_bytes;
 
-    /** Estimated number of signature chunks */
-    int                 estimated_signature_count;
-    
     /** Command byte currently being processed, if any. */
     unsigned char       op;
 

--- a/src/mksum.c
+++ b/src/mksum.c
@@ -67,7 +67,8 @@ static rs_result rs_sig_s_header(rs_job_t *job)
     rs_signature_t *sig = job->signature;
     rs_result result;
 
-    if ((result = rs_signature_init(sig, job->magic, job->block_len, job->strong_sum_len, 0)) != RS_DONE)
+    if ((result = rs_signature_init(sig, job->sig_magic, job->sig_block_len,
+				    job->sig_strong_len, 0)) != RS_DONE)
         return result;
     rs_squirt_n4(job, sig->magic);
     rs_squirt_n4(job, sig->block_len);
@@ -94,7 +95,7 @@ rs_sig_do_block(rs_job_t *job, const void *block, size_t len)
     rs_strong_sum_t     strong_sum;
 
     weak_sum = rs_calc_weak_sum(block, len);
-    rs_signature_calc_strong_sum(job->signature, block, len, &strong_sum);
+    rs_signature_calc_strong_sum(sig, block, len, &strong_sum);
     rs_squirt_n4(job, weak_sum);
     rs_tube_write(job, strong_sum, sig->strong_sum_len);
     if (rs_trace_enabled()) {
@@ -147,8 +148,8 @@ rs_job_t * rs_sig_begin(size_t new_block_len, size_t strong_sum_len,
     job = rs_job_new("signature", rs_sig_s_header);
     job->signature = rs_alloc_struct(rs_signature_t);
     job->job_owns_sig = 1;
-    job->magic = sig_magic;
-    job->block_len = new_block_len;
-    job->strong_sum_len = strong_sum_len;
+    job->sig_magic = sig_magic;
+    job->sig_block_len = new_block_len;
+    job->sig_strong_len = strong_sum_len;
     return job;
 }

--- a/src/mksum.c
+++ b/src/mksum.c
@@ -140,37 +140,14 @@ static rs_result rs_sig_s_generate(rs_job_t *job)
 rs_job_t *rs_sig_begin(size_t new_block_len, size_t strong_sum_len, rs_magic_number sig_magic)
 {
     rs_job_t *job;
-    int native_length;
+    rs_signature_t sig;
 
     job = rs_job_new("signature", rs_sig_s_header);
-    job->block_len = new_block_len;
-
-    if (!sig_magic)
-        sig_magic = RS_BLAKE2_SIG_MAGIC;
-
-    switch (sig_magic) {
-    case RS_BLAKE2_SIG_MAGIC:
-        native_length = RS_BLAKE2_SUM_LENGTH;
-        job->magic = sig_magic;
-        break;
-    case RS_MD4_SIG_MAGIC:
-        job->magic = sig_magic;
-        native_length = RS_MD4_SUM_LENGTH;
-        break;
-    default:
-        rs_error("invalid sig_magic %#lx", (unsigned long)sig_magic);
+    if (rs_signature_init(&sig, sig_magic, new_block_len, strong_sum_len, 0) != RS_DONE)
         return NULL;
-    }
-
-    if (!strong_sum_len)
-        job->strong_sum_len = native_length;
-    else {
-        assert(strong_sum_len <= native_length);
-        job->strong_sum_len = strong_sum_len;
-    }
-
+    job->magic = sig.magic;
+    job->block_len = sig.block_len;
+    job->strong_sum_len = sig.strong_sum_len;
+    rs_signature_done(&sig);
     return job;
 }
-
-/* vim: expandtab shiftwidth=4
- */

--- a/src/mksum.c
+++ b/src/mksum.c
@@ -20,6 +20,7 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
+
 /**
  * \file mksum.c Generate file signatures.
  **/
@@ -50,9 +51,12 @@
 #include "netint.h"
 #include "trace.h"
 
+
 /* Possible state functions for signature generation. */
 static rs_result rs_sig_s_header(rs_job_t *);
 static rs_result rs_sig_s_generate(rs_job_t *);
+
+
 
 /**
  * State of trying to send the signature header.
@@ -76,30 +80,32 @@ static rs_result rs_sig_s_header(rs_job_t *job)
     rs_squirt_n4(job, job->magic);
     rs_squirt_n4(job, job->block_len);
     rs_squirt_n4(job, job->strong_sum_len);
-    rs_trace("sent header (magic %#x, block len = %d, strong sum len = %d)", job->magic, (int)job->block_len,
-             (int)job->strong_sum_len);
+    rs_trace("sent header (magic %#x, block len = %d, strong sum len = %d)",
+             job->magic, (int) job->block_len, (int) job->strong_sum_len);
     job->stats.block_len = job->block_len;
 
     job->statefn = rs_sig_s_generate;
     return RS_RUNNING;
 }
 
+
 /**
  * Generate the checksums for a block and write it out.  Called when
  * we already know we have enough data in memory at \p block.
  * \private
  */
-static rs_result rs_sig_do_block(rs_job_t *job, const void *block, size_t len)
+static rs_result
+rs_sig_do_block(rs_job_t *job, const void *block, size_t len)
 {
-    rs_weak_sum_t weak_sum;
-    rs_strong_sum_t strong_sum;
+    rs_weak_sum_t       weak_sum;
+    rs_strong_sum_t     strong_sum;
 
     weak_sum = rs_calc_weak_sum(block, len);
     rs_signature_calc_strong_sum(job->signature, block, len, &strong_sum);
     rs_squirt_n4(job, weak_sum);
     rs_tube_write(job, strong_sum, job->strong_sum_len);
     if (rs_trace_enabled()) {
-        char strong_sum_hex[RS_MAX_STRONG_SUM_LENGTH * 2 + 1];
+        char                strong_sum_hex[RS_MAX_STRONG_SUM_LENGTH * 2 + 1];
         rs_hexify(strong_sum_hex, strong_sum, job->strong_sum_len);
         rs_trace("sent block: weak=0x%08x, strong=%s", weak_sum, strong_sum_hex);
     }
@@ -107,15 +113,17 @@ static rs_result rs_sig_do_block(rs_job_t *job, const void *block, size_t len)
     return RS_RUNNING;
 }
 
+
 /**
  * State of reading a block and trying to generate its sum.
  * \private
  */
-static rs_result rs_sig_s_generate(rs_job_t *job)
+static rs_result
+rs_sig_s_generate(rs_job_t *job)
 {
-    rs_result result;
-    size_t len;
-    void *block;
+    rs_result           result;
+    size_t              len;
+    void                *block;
 
     /* must get a whole block, otherwise try again */
     len = job->block_len;
@@ -134,11 +142,15 @@ static rs_result rs_sig_s_generate(rs_job_t *job)
         rs_trace("generate stopped: %s", rs_strerror(result));
         return result;
     }
-    rs_trace("got %ld byte block", (long)len);
+
+    rs_trace("got %ld byte block", (long) len);
+
     return rs_sig_do_block(job, block, len);
 }
 
-rs_job_t *rs_sig_begin(size_t new_block_len, size_t strong_sum_len, rs_magic_number sig_magic)
+
+rs_job_t * rs_sig_begin(size_t new_block_len, size_t strong_sum_len,
+                        rs_magic_number sig_magic)
 {
     rs_job_t *job;
 

--- a/src/mksum.c
+++ b/src/mksum.c
@@ -20,7 +20,6 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-
 /**
  * \file mksum.c Generate file signatures.
  **/
@@ -52,12 +51,9 @@
 #include "trace.h"
 #include "checksum.h"
 
-
 /* Possible state functions for signature generation. */
 static rs_result rs_sig_s_header(rs_job_t *);
 static rs_result rs_sig_s_generate(rs_job_t *);
-
-
 
 /**
  * State of trying to send the signature header.
@@ -68,34 +64,32 @@ static rs_result rs_sig_s_header(rs_job_t *job)
     rs_squirt_n4(job, job->magic);
     rs_squirt_n4(job, job->block_len);
     rs_squirt_n4(job, job->strong_sum_len);
-    rs_trace("sent header (magic %#x, block len = %d, strong sum len = %d)",
-             job->magic, (int) job->block_len, (int) job->strong_sum_len);
+    rs_trace("sent header (magic %#x, block len = %d, strong sum len = %d)", job->magic, (int)job->block_len,
+             (int)job->strong_sum_len);
     job->stats.block_len = job->block_len;
 
     job->statefn = rs_sig_s_generate;
     return RS_RUNNING;
 }
 
-
 /**
  * Generate the checksums for a block and write it out.  Called when
  * we already know we have enough data in memory at \p block.
  * \private
  */
-static rs_result
-rs_sig_do_block(rs_job_t *job, const void *block, size_t len)
+static rs_result rs_sig_do_block(rs_job_t *job, const void *block, size_t len)
 {
-    rs_weak_sum_t       weak_sum;
-    rs_strong_sum_t     strong_sum;
+    rs_weak_sum_t weak_sum;
+    rs_strong_sum_t strong_sum;
 
     weak_sum = rs_calc_weak_sum(block, len);
 
     if (job->magic == RS_BLAKE2_SIG_MAGIC) {
         rs_calc_blake2_sum(block, len, &strong_sum);
-    } else if(job->magic == RS_MD4_SIG_MAGIC) {
+    } else if (job->magic == RS_MD4_SIG_MAGIC) {
         rs_calc_md4_sum(block, len, &strong_sum);
     } else {
-        rs_error("BUG: invalid job magic %#lx", (unsigned long) job->magic);
+        rs_error("BUG: invalid job magic %#lx", (unsigned long)job->magic);
         return RS_INTERNAL_ERROR;
     }
 
@@ -103,10 +97,9 @@ rs_sig_do_block(rs_job_t *job, const void *block, size_t len)
     rs_tube_write(job, strong_sum, job->strong_sum_len);
 
     if (rs_trace_enabled()) {
-        char                strong_sum_hex[RS_MAX_STRONG_SUM_LENGTH * 2 + 1];
+        char strong_sum_hex[RS_MAX_STRONG_SUM_LENGTH * 2 + 1];
         rs_hexify(strong_sum_hex, strong_sum, job->strong_sum_len);
-        rs_trace("sent weak sum 0x%08x and strong sum %s", weak_sum,
-                 strong_sum_hex);
+        rs_trace("sent weak sum 0x%08x and strong sum %s", weak_sum, strong_sum_hex);
     }
 
     job->stats.sig_blocks++;
@@ -114,17 +107,15 @@ rs_sig_do_block(rs_job_t *job, const void *block, size_t len)
     return RS_RUNNING;
 }
 
-
 /**
  * State of reading a block and trying to generate its sum.
  * \private
  */
-static rs_result
-rs_sig_s_generate(rs_job_t *job)
+static rs_result rs_sig_s_generate(rs_job_t *job)
 {
-    rs_result           result;
-    size_t              len;
-    void                *block;
+    rs_result result;
+    size_t len;
+    void *block;
 
     /* must get a whole block, otherwise try again */
     len = job->block_len;
@@ -141,14 +132,12 @@ rs_sig_s_generate(rs_job_t *job)
         return result;
     }
 
-    rs_trace("got %ld byte block", (long) len);
+    rs_trace("got %ld byte block", (long)len);
 
     return rs_sig_do_block(job, block, len);
 }
 
-
-rs_job_t * rs_sig_begin(size_t new_block_len, size_t strong_sum_len,
-                        rs_magic_number sig_magic)
+rs_job_t *rs_sig_begin(size_t new_block_len, size_t strong_sum_len, rs_magic_number sig_magic)
 {
     rs_job_t *job;
     int native_length;
@@ -169,7 +158,7 @@ rs_job_t * rs_sig_begin(size_t new_block_len, size_t strong_sum_len,
         native_length = RS_MD4_SUM_LENGTH;
         break;
     default:
-        rs_error("invalid sig_magic %#lx", (unsigned long) sig_magic);
+        rs_error("invalid sig_magic %#lx", (unsigned long)sig_magic);
         return NULL;
     }
 

--- a/src/mksum.c
+++ b/src/mksum.c
@@ -67,12 +67,8 @@ static rs_result rs_sig_s_header(rs_job_t *job)
     rs_signature_t *sig = job->signature;
     rs_result result;
 
-    if ((result = rs_signature_init(sig, job->magic, job->block_len, job->strong_sum_len, 0)) != RS_DONE) {
-        /* Make sure signature is freed when we are done. */
-        rs_free_sumset(sig);
-        job->signature = NULL;
+    if ((result = rs_signature_init(sig, job->magic, job->block_len, job->strong_sum_len, 0)) != RS_DONE)
         return result;
-    }
     /* Set the job values back to the signature values. */
     job->magic = sig->magic;
     job->block_len = sig->block_len;
@@ -134,9 +130,6 @@ rs_sig_s_generate(rs_job_t *job)
     if ((result == RS_BLOCKED && rs_job_input_is_ending(job))) {
         result = rs_scoop_read_rest(job, &len, &block);
     } else if (result == RS_INPUT_ENDED) {
-        /* Make sure the signature is freed when we are done. */
-        rs_free_sumset(job->signature);
-        job->signature = NULL;
         return RS_DONE;
     } else if (result != RS_DONE) {
         rs_trace("generate stopped: %s", rs_strerror(result));
@@ -156,6 +149,7 @@ rs_job_t * rs_sig_begin(size_t new_block_len, size_t strong_sum_len,
 
     job = rs_job_new("signature", rs_sig_s_header);
     job->signature = rs_alloc_struct(rs_signature_t);
+    job->job_owns_sig = 1;
     job->magic = sig_magic;
     job->block_len = new_block_len;
     job->strong_sum_len = strong_sum_len;

--- a/src/readsums.c
+++ b/src/readsums.c
@@ -104,9 +104,10 @@ static rs_result rs_loadsig_s_stronglen(rs_job_t *job)
         return RS_CORRUPT;
     }
     rs_trace("got strong sum length %d", l);
-    job->strong_sum_len = l;
+    job->sig_strong_len = l;
     /* Initialize the signature. */
-    if ((result = rs_signature_init(job->signature, job->magic, job->block_len, job->strong_sum_len,
+    if ((result = rs_signature_init(job->signature, job->sig_magic,
+				    job->sig_block_len, job->sig_strong_len,
 				    job->sig_fsize)) != RS_DONE)
         return result;
     job->statefn = rs_loadsig_s_weak;
@@ -126,7 +127,7 @@ static rs_result rs_loadsig_s_blocklen(rs_job_t *job)
         return RS_CORRUPT;
     }
     rs_trace("got block length %d", l);
-    job->block_len = l;
+    job->sig_block_len = l;
     job->stats.block_len = l;
     job->statefn = rs_loadsig_s_stronglen;
     return RS_RUNNING;
@@ -141,7 +142,7 @@ static rs_result rs_loadsig_s_magic(rs_job_t *job)
     if ((result = rs_suck_n4(job, &l)) != RS_DONE)
         return result;
     rs_trace("got signature magic %#10x", l);
-    job->magic = l;
+    job->sig_magic = l;
     job->statefn = rs_loadsig_s_blocklen;
     return RS_RUNNING;
 }

--- a/src/readsums.c
+++ b/src/readsums.c
@@ -105,11 +105,9 @@ static rs_result rs_loadsig_s_stronglen(rs_job_t *job)
     }
     rs_trace("got strong sum length %d", l);
     job->strong_sum_len = l;
-    /* Estimate the number of blocks stored in signature if we know the sig filesize. */
-    /* Magic+header is 12 bytes, each block thereafter is 4 bytes weak_sum+strong_sum_len bytes */
-    l = job->sig_file_bytes ? (job->sig_file_bytes - 12) / (4 + job->strong_sum_len) : 0;
     /* Initialize the signature. */
-    if ((result = rs_signature_init(job->signature, job->magic, job->block_len, job->strong_sum_len, l)) != RS_DONE)
+    if ((result = rs_signature_init(job->signature, job->magic, job->block_len, job->strong_sum_len,
+				    job->sig_fsize)) != RS_DONE)
         return result;
     job->statefn = rs_loadsig_s_weak;
     return RS_RUNNING;

--- a/src/readsums.c
+++ b/src/readsums.c
@@ -20,7 +20,6 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-
 /**
  * \file readsums.c
  * \brief Load signatures from a file.
@@ -41,20 +40,17 @@
 #include "util.h"
 #include "stream.h"
 
-
 static rs_result rs_loadsig_s_weak(rs_job_t *job);
 static rs_result rs_loadsig_s_strong(rs_job_t *job);
-
-
 
 /**
  * Add a just-read-in checksum pair to the signature block.
  */
 static rs_result rs_loadsig_add_sum(rs_job_t *job, rs_strong_sum_t *strong)
 {
-    size_t              new_size;
-    rs_signature_t      *sig = job->signature;
-    rs_block_sig_t      *asignature;
+    size_t new_size;
+    rs_signature_t *sig = job->signature;
+    rs_block_sig_t *asignature;
 
     sig->count++;
     if (sig->count > job->estimated_signature_count) {
@@ -76,11 +72,10 @@ static rs_result rs_loadsig_add_sum(rs_job_t *job, rs_strong_sum_t *strong)
     memcpy(asignature->strong_sum, strong, sig->strong_sum_len);
 
     if (rs_trace_enabled()) {
-        char                hexbuf[RS_MAX_STRONG_SUM_LENGTH * 2 + 2];
+        char hexbuf[RS_MAX_STRONG_SUM_LENGTH * 2 + 2];
         rs_hexify(hexbuf, strong, sig->strong_sum_len);
 
-        rs_trace("read in checksum: weak=%#x, strong=%s", asignature->weak_sum,
-                 hexbuf);
+        rs_trace("read in checksum: weak=%#x, strong=%s", asignature->weak_sum, hexbuf);
     }
 
     job->stats.sig_blocks++;
@@ -88,16 +83,14 @@ static rs_result rs_loadsig_add_sum(rs_job_t *job, rs_strong_sum_t *strong)
     return RS_RUNNING;
 }
 
-
 static rs_result rs_loadsig_s_weak(rs_job_t *job)
 {
-    int                 l;
-    rs_result           result;
+    int l;
+    rs_result result;
 
     result = rs_suck_n4(job, &l);
-    if (result == RS_DONE)
-        ;
-    else if (result == RS_INPUT_ENDED) /* ending here is OK */
+    if (result == RS_DONE) ;
+    else if (result == RS_INPUT_ENDED)  /* ending here is OK */
         return RS_DONE;
     else
         return result;
@@ -109,53 +102,48 @@ static rs_result rs_loadsig_s_weak(rs_job_t *job)
     return RS_RUNNING;
 }
 
-
-
 static rs_result rs_loadsig_s_strong(rs_job_t *job)
 {
-    rs_result           result;
-    rs_strong_sum_t     *strongsum;
+    rs_result result;
+    rs_strong_sum_t *strongsum;
 
-    result = rs_scoop_read(job, job->signature->strong_sum_len,
-                           (void **) &strongsum);
-    if (result != RS_DONE) return result;
+    result = rs_scoop_read(job, job->signature->strong_sum_len, (void **)&strongsum);
+    if (result != RS_DONE)
+        return result;
 
     job->statefn = rs_loadsig_s_weak;
 
     return rs_loadsig_add_sum(job, strongsum);
 }
 
-
-
 static rs_result rs_loadsig_s_stronglen(rs_job_t *job)
 {
-    int                 l;
-    rs_result           result;
+    int l;
+    rs_result result;
 
     if ((result = rs_suck_n4(job, &l)) != RS_DONE)
         return result;
     job->strong_sum_len = l;
-    
-    if (l < 0  ||  l > RS_MAX_STRONG_SUM_LENGTH) {
+
+    if (l < 0 || l > RS_MAX_STRONG_SUM_LENGTH) {
         rs_error("strong sum length %d is implausible", l);
         return RS_CORRUPT;
     }
 
     job->signature->block_len = job->block_len;
     job->signature->strong_sum_len = job->strong_sum_len;
-    
-    rs_trace("allocated sigset_t (strong_sum_len=%d, block_len=%d)",
-             (int) job->strong_sum_len, (int) job->block_len);
+
+    rs_trace("allocated sigset_t (strong_sum_len=%d, block_len=%d)", (int)job->strong_sum_len, (int)job->block_len);
 
     job->statefn = rs_loadsig_s_weak;
-    
+
     /* Estimate the number of blocks stored in signature */
     /* Magic+header is 12 bytes,
        each block thereafter is 4 bytes weak_sum+strong_sum_len bytes */
     if ((job->estimated_signature_count == 0) && (job->sig_file_bytes > 0)) {
-        job->estimated_signature_count = (job->sig_file_bytes-12)/(4+job->strong_sum_len);
-        rs_trace("estimating %d blocks in signature (%d bytes)",
-            job->estimated_signature_count, job->estimated_signature_count*sizeof(rs_block_sig_t));
+        job->estimated_signature_count = (job->sig_file_bytes - 12) / (4 + job->strong_sum_len);
+        rs_trace("estimating %d blocks in signature (%d bytes)", job->estimated_signature_count,
+                 job->estimated_signature_count * sizeof(rs_block_sig_t));
     }
 
     /* Allocate memory for signature sums */
@@ -170,53 +158,50 @@ static rs_result rs_loadsig_s_stronglen(rs_job_t *job)
     return RS_RUNNING;
 }
 
-
 static rs_result rs_loadsig_s_blocklen(rs_job_t *job)
 {
-    int                 l;
-    rs_result           result;
+    int l;
+    rs_result result;
 
     if ((result = rs_suck_n4(job, &l)) != RS_DONE)
         return result;
     job->block_len = l;
 
     if (job->block_len < 1) {
-        rs_error("block length of %d is bogus", (int) job->block_len);
+        rs_error("block length of %d is bogus", (int)job->block_len);
         return RS_CORRUPT;
     }
 
     job->statefn = rs_loadsig_s_stronglen;
     job->stats.block_len = job->block_len;
-        
+
     return RS_RUNNING;
 }
 
-
 static rs_result rs_loadsig_s_magic(rs_job_t *job)
 {
-    int                 l;
-    rs_result           result;
+    int l;
+    rs_result result;
 
     if ((result = rs_suck_n4(job, &l)) != RS_DONE) {
         return result;
     }
 
-    switch(l) {
-        case RS_MD4_SIG_MAGIC:
-        case RS_BLAKE2_SIG_MAGIC:
-            job->magic = job->signature->magic = l;
-            rs_trace("got signature magic %#10x", l);
-            break;
-	default:
-            rs_error("wrong magic number %#10x for signature", l);
-            return RS_BAD_MAGIC;
+    switch (l) {
+    case RS_MD4_SIG_MAGIC:
+    case RS_BLAKE2_SIG_MAGIC:
+        job->magic = job->signature->magic = l;
+        rs_trace("got signature magic %#10x", l);
+        break;
+    default:
+        rs_error("wrong magic number %#10x for signature", l);
+        return RS_BAD_MAGIC;
     }
 
     job->statefn = rs_loadsig_s_blocklen;
 
     return RS_RUNNING;
 }
-
 
 rs_job_t *rs_loadsig_begin(rs_signature_t **signature)
 {

--- a/src/readsums.c
+++ b/src/readsums.c
@@ -20,6 +20,7 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
+
 /**
  * \file readsums.c
  * \brief Load signatures from a file.
@@ -40,13 +41,14 @@
 #include "util.h"
 #include "stream.h"
 
+
 static rs_result rs_loadsig_s_weak(rs_job_t *job);
 static rs_result rs_loadsig_s_strong(rs_job_t *job);
 
 static rs_result rs_loadsig_s_weak(rs_job_t *job)
 {
-    int l;
-    rs_result result;
+    int                 l;
+    rs_result           result;
 
     if ((result = rs_suck_n4(job, &l)) != RS_DONE) {
         if (result == RS_INPUT_ENDED)   /* ending here is OK */
@@ -58,10 +60,12 @@ static rs_result rs_loadsig_s_weak(rs_job_t *job)
     return RS_RUNNING;
 }
 
+
+
 static rs_result rs_loadsig_s_strong(rs_job_t *job)
 {
-    rs_result result;
-    rs_strong_sum_t *strong_sum;
+    rs_result           result;
+    rs_strong_sum_t     *strong_sum;
 
     if ((result = rs_scoop_read(job, job->signature->strong_sum_len, (void **)&strong_sum)) != RS_DONE)
         return result;
@@ -76,14 +80,16 @@ static rs_result rs_loadsig_s_strong(rs_job_t *job)
     return RS_RUNNING;
 }
 
+
+
 static rs_result rs_loadsig_s_stronglen(rs_job_t *job)
 {
-    int l;
-    rs_result result;
+    int                 l;
+    rs_result           result;
 
     if ((result = rs_suck_n4(job, &l)) != RS_DONE)
         return result;
-    if (l < 0 || l > RS_MAX_STRONG_SUM_LENGTH) {
+    if (l < 0  ||  l > RS_MAX_STRONG_SUM_LENGTH) {
         rs_error("strong sum length %d is implausible", l);
         return RS_CORRUPT;
     }
@@ -99,10 +105,11 @@ static rs_result rs_loadsig_s_stronglen(rs_job_t *job)
     return RS_RUNNING;
 }
 
+
 static rs_result rs_loadsig_s_blocklen(rs_job_t *job)
 {
-    int l;
-    rs_result result;
+    int                 l;
+    rs_result           result;
 
     if ((result = rs_suck_n4(job, &l)) != RS_DONE)
         return result;
@@ -117,10 +124,11 @@ static rs_result rs_loadsig_s_blocklen(rs_job_t *job)
     return RS_RUNNING;
 }
 
+
 static rs_result rs_loadsig_s_magic(rs_job_t *job)
 {
-    int l;
-    rs_result result;
+    int                 l;
+    rs_result           result;
 
     if ((result = rs_suck_n4(job, &l)) != RS_DONE)
         return result;
@@ -129,6 +137,7 @@ static rs_result rs_loadsig_s_magic(rs_job_t *job)
     job->statefn = rs_loadsig_s_blocklen;
     return RS_RUNNING;
 }
+
 
 rs_job_t *rs_loadsig_begin(rs_signature_t **signature)
 {

--- a/src/readsums.c
+++ b/src/readsums.c
@@ -43,77 +43,37 @@
 static rs_result rs_loadsig_s_weak(rs_job_t *job);
 static rs_result rs_loadsig_s_strong(rs_job_t *job);
 
-/**
- * Add a just-read-in checksum pair to the signature block.
- */
-static rs_result rs_loadsig_add_sum(rs_job_t *job, rs_strong_sum_t *strong)
-{
-    size_t new_size;
-    rs_signature_t *sig = job->signature;
-    rs_block_sig_t *asignature;
-
-    sig->count++;
-    if (sig->count > job->estimated_signature_count) {
-
-        job->estimated_signature_count = sig->count;
-        new_size = sig->count * sizeof(rs_block_sig_t);
-
-        sig->block_sigs = realloc(sig->block_sigs, new_size);
-    }
-
-    if (sig->block_sigs == NULL) {
-        return RS_MEM_ERROR;
-    }
-    asignature = &(sig->block_sigs[sig->count - 1]);
-
-    asignature->weak_sum = job->weak_sig;
-    asignature->i = sig->count;
-
-    memcpy(asignature->strong_sum, strong, sig->strong_sum_len);
-
-    if (rs_trace_enabled()) {
-        char hexbuf[RS_MAX_STRONG_SUM_LENGTH * 2 + 2];
-        rs_hexify(hexbuf, strong, sig->strong_sum_len);
-
-        rs_trace("read in checksum: weak=%#x, strong=%s", asignature->weak_sum, hexbuf);
-    }
-
-    job->stats.sig_blocks++;
-
-    return RS_RUNNING;
-}
-
 static rs_result rs_loadsig_s_weak(rs_job_t *job)
 {
     int l;
     rs_result result;
 
-    result = rs_suck_n4(job, &l);
-    if (result == RS_DONE) ;
-    else if (result == RS_INPUT_ENDED)  /* ending here is OK */
-        return RS_DONE;
-    else
+    if ((result = rs_suck_n4(job, &l)) != RS_DONE) {
+        if (result == RS_INPUT_ENDED)   /* ending here is OK */
+            return RS_DONE;
         return result;
-
+    }
     job->weak_sig = l;
-
     job->statefn = rs_loadsig_s_strong;
-
     return RS_RUNNING;
 }
 
 static rs_result rs_loadsig_s_strong(rs_job_t *job)
 {
     rs_result result;
-    rs_strong_sum_t *strongsum;
+    rs_strong_sum_t *strong_sum;
 
-    result = rs_scoop_read(job, job->signature->strong_sum_len, (void **)&strongsum);
-    if (result != RS_DONE)
+    if ((result = rs_scoop_read(job, job->signature->strong_sum_len, (void **)&strong_sum)) != RS_DONE)
         return result;
-
+    if (rs_trace_enabled()) {
+        char hexbuf[RS_MAX_STRONG_SUM_LENGTH * 2 + 2];
+        rs_hexify(hexbuf, strong_sum, job->strong_sum_len);
+        rs_trace("got block: weak=%#x, strong=%s", job->weak_sig, hexbuf);
+    }
+    rs_signature_add_block(job->signature, job->weak_sig, strong_sum);
+    job->stats.sig_blocks++;
     job->statefn = rs_loadsig_s_weak;
-
-    return rs_loadsig_add_sum(job, strongsum);
+    return RS_RUNNING;
 }
 
 static rs_result rs_loadsig_s_stronglen(rs_job_t *job)
@@ -123,38 +83,19 @@ static rs_result rs_loadsig_s_stronglen(rs_job_t *job)
 
     if ((result = rs_suck_n4(job, &l)) != RS_DONE)
         return result;
-    job->strong_sum_len = l;
-
     if (l < 0 || l > RS_MAX_STRONG_SUM_LENGTH) {
         rs_error("strong sum length %d is implausible", l);
         return RS_CORRUPT;
     }
-
-    job->signature->block_len = job->block_len;
-    job->signature->strong_sum_len = job->strong_sum_len;
-
-    rs_trace("allocated sigset_t (strong_sum_len=%d, block_len=%d)", (int)job->strong_sum_len, (int)job->block_len);
-
+    rs_trace("got strong sum length %d", l);
+    job->strong_sum_len = l;
+    /* Estimate the number of blocks stored in signature if we know the sig filesize. */
+    /* Magic+header is 12 bytes, each block thereafter is 4 bytes weak_sum+strong_sum_len bytes */
+    l = job->sig_file_bytes ? (job->sig_file_bytes - 12) / (4 + job->strong_sum_len) : 0;
+    /* Initialize the signature. */
+    if ((result = rs_signature_init(job->signature, job->magic, job->block_len, job->strong_sum_len, l)) != RS_DONE)
+        return result;
     job->statefn = rs_loadsig_s_weak;
-
-    /* Estimate the number of blocks stored in signature */
-    /* Magic+header is 12 bytes,
-       each block thereafter is 4 bytes weak_sum+strong_sum_len bytes */
-    if ((job->estimated_signature_count == 0) && (job->sig_file_bytes > 0)) {
-        job->estimated_signature_count = (job->sig_file_bytes - 12) / (4 + job->strong_sum_len);
-        rs_trace("estimating %d blocks in signature (%d bytes)", job->estimated_signature_count,
-                 job->estimated_signature_count * sizeof(rs_block_sig_t));
-    }
-
-    /* Allocate memory for signature sums */
-    if (job->estimated_signature_count > 0) {
-        job->signature->block_sigs = calloc(job->estimated_signature_count, sizeof(rs_block_sig_t));
-        if (job->signature->block_sigs == NULL) {
-            job->estimated_signature_count = 0;
-            return RS_MEM_ERROR;
-        }
-    }
-
     return RS_RUNNING;
 }
 
@@ -165,16 +106,14 @@ static rs_result rs_loadsig_s_blocklen(rs_job_t *job)
 
     if ((result = rs_suck_n4(job, &l)) != RS_DONE)
         return result;
-    job->block_len = l;
-
-    if (job->block_len < 1) {
-        rs_error("block length of %d is bogus", (int)job->block_len);
+    if (l < 1) {
+        rs_error("block length of %d is bogus", l);
         return RS_CORRUPT;
     }
-
+    rs_trace("got block length %d", l);
+    job->block_len = l;
+    job->stats.block_len = l;
     job->statefn = rs_loadsig_s_stronglen;
-    job->stats.block_len = job->block_len;
-
     return RS_RUNNING;
 }
 
@@ -183,23 +122,11 @@ static rs_result rs_loadsig_s_magic(rs_job_t *job)
     int l;
     rs_result result;
 
-    if ((result = rs_suck_n4(job, &l)) != RS_DONE) {
+    if ((result = rs_suck_n4(job, &l)) != RS_DONE)
         return result;
-    }
-
-    switch (l) {
-    case RS_MD4_SIG_MAGIC:
-    case RS_BLAKE2_SIG_MAGIC:
-        job->magic = job->signature->magic = l;
-        rs_trace("got signature magic %#10x", l);
-        break;
-    default:
-        rs_error("wrong magic number %#10x for signature", l);
-        return RS_BAD_MAGIC;
-    }
-
+    rs_trace("got signature magic %#10x", l);
+    job->magic = l;
     job->statefn = rs_loadsig_s_blocklen;
-
     return RS_RUNNING;
 }
 
@@ -209,7 +136,5 @@ rs_job_t *rs_loadsig_begin(rs_signature_t **signature)
 
     job = rs_job_new("loadsig", rs_loadsig_s_magic);
     *signature = job->signature = rs_alloc_struct(rs_signature_t);
-    job->signature->count = 0;
-
     return job;
 }

--- a/src/search.c
+++ b/src/search.c
@@ -43,7 +43,6 @@
 #include "util.h"
 #include "sumset.h"
 #include "search.h"
-#include "checksum.h"
 
 #define TABLE_SIZE (1<<16)
 #define NULL_TAG (-1)
@@ -194,16 +193,7 @@ rs_search_for_block(rs_weak_sum_t weak_sum,
         if (v == 0) {
             if (!got_strong) {
                 /* Lazy calculate strong sum after finding weak match. */
-                if(sig->magic == RS_BLAKE2_SIG_MAGIC) {
-                    rs_calc_blake2_sum(inbuf, block_len, &strong_sum);
-                } else if (sig->magic == RS_MD4_SIG_MAGIC) {
-                    rs_calc_md4_sum(inbuf, block_len, &strong_sum);
-                } else {
-                    /* Bad input data is checked in rs_delta_begin, so this
-                     * should never be reached. */
-                    rs_fatal("Unknown signature algorithm %#x", sig->magic);
-                    return 0;
-                }
+		rs_signature_calc_strong_sum(sig, inbuf, block_len, &strong_sum);
                 got_strong = 1;
             }
             v = memcmp(strong_sum, b->strong_sum, sig->strong_sum_len);
@@ -227,14 +217,7 @@ rs_search_for_block(rs_weak_sum_t weak_sum,
         if (weak_sum != b->weak_sum)
             return 0;
         if (!got_strong) {
-            if(sig->magic == RS_BLAKE2_SIG_MAGIC) {
-                rs_calc_blake2_sum(inbuf, block_len, &strong_sum);
-            } else if (sig->magic == RS_MD4_SIG_MAGIC) {
-                rs_calc_md4_sum(inbuf, block_len, &strong_sum);
-            } else {
-                rs_error("Unknown signature algorithm - this is a BUG");
-                return 0; /* FIXME: Is this the best way to handle this? */
-            }
+	    rs_signature_calc_strong_sum(sig, inbuf, block_len, &strong_sum);
             got_strong = 1;
         }
         v = memcmp(strong_sum, b->strong_sum, sig->strong_sum_len);

--- a/src/sumset.c
+++ b/src/sumset.c
@@ -58,8 +58,8 @@ rs_result rs_signature_init(rs_signature_t *sig, int magic, int block_len, int s
         return RS_BAD_MAGIC;
     }
     strong_len = strong_len ? strong_len : max_strong_len;
-    if (strong_len > max_strong_len) {
-        rs_error("invalid strong_sum_len %d > %d for magic %#x", strong_len, max_strong_len, magic);
+    if (strong_len < 1 || max_strong_len < strong_len) {
+        rs_error("invalid strong_sum_len %d for magic %#x", strong_len, magic);
         return RS_PARAM_ERROR;
     }
     /* Set attributes from args. */
@@ -73,6 +73,7 @@ rs_result rs_signature_init(rs_signature_t *sig, int magic, int block_len, int s
     sig->targets = NULL;
     if (block_num)
         sig->block_sigs = rs_alloc(block_num * sizeof(rs_block_sig_t), "signature->block_sigs");
+    rs_signature_check(sig);
     return RS_DONE;
 }
 
@@ -86,7 +87,7 @@ void rs_signature_done(rs_signature_t *sig)
 
 rs_block_sig_t *rs_signature_add_block(rs_signature_t *sig, rs_weak_sum_t weak_sum, rs_strong_sum_t *strong_sum)
 {
-    assert(0 <= sig->count && sig->count <= sig->size);
+    rs_signature_check(sig);
     /* If block_sigs is full, allocate more space. */
     if (sig->count == sig->size) {
         sig->size = sig->size ? sig->size * 2 : 16;

--- a/src/sumset.c
+++ b/src/sumset.c
@@ -31,39 +31,30 @@
 #include "util.h"
 #include "trace.h"
 
-
-void
-rs_free_sumset(rs_signature_t * psums)
+void rs_free_sumset(rs_signature_t *psums)
 {
-        if (psums->block_sigs)
-                free(psums->block_sigs);
+    if (psums->block_sigs)
+        free(psums->block_sigs);
 
-        if (psums->tag_table)
-		free(psums->tag_table);
+    if (psums->tag_table)
+        free(psums->tag_table);
 
-        if (psums->targets)
-                free(psums->targets);
+    if (psums->targets)
+        free(psums->targets);
 
-        rs_bzero(psums, sizeof *psums);
-        free(psums);
+    rs_bzero(psums, sizeof *psums);
+    free(psums);
 }
 
-
-void
-rs_sumset_dump(rs_signature_t const *sums)
+void rs_sumset_dump(rs_signature_t const *sums)
 {
-        int i;
-        char        strong_hex[RS_MAX_STRONG_SUM_LENGTH * 3];
-    
-        rs_log(RS_LOG_INFO,
-                "sumset info: magic=%x, block_len=%d, block_num=%d",
-                sums->magic, sums->block_len, sums->count);
+    int i;
+    char strong_hex[RS_MAX_STRONG_SUM_LENGTH * 3];
 
-        for (i = 0; i < sums->count; i++) {
-                rs_hexify(strong_hex, sums->block_sigs[i].strong_sum,
-                          sums->strong_sum_len);
-                rs_log(RS_LOG_INFO,
-                        "sum %6d: weak=%08x, strong=%s",
-                        i, sums->block_sigs[i].weak_sum, strong_hex);
-        }
+    rs_log(RS_LOG_INFO, "sumset info: magic=%x, block_len=%d, block_num=%d", sums->magic, sums->block_len, sums->count);
+
+    for (i = 0; i < sums->count; i++) {
+        rs_hexify(strong_hex, sums->block_sigs[i].strong_sum, sums->strong_sum_len);
+        rs_log(RS_LOG_INFO, "sum %6d: weak=%08x, strong=%s", i, sums->block_sigs[i].weak_sum, strong_hex);
+    }
 }

--- a/src/sumset.c
+++ b/src/sumset.c
@@ -25,24 +25,81 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 
 #include "librsync.h"
 #include "sumset.h"
 #include "util.h"
 #include "trace.h"
 
+void rs_block_sig_init(rs_block_sig_t *sig, int i, rs_weak_sum_t weak_sum, rs_strong_sum_t *strong_sum,
+                       int strong_len)
+{
+    sig->i = i;
+    sig->weak_sum = weak_sum;
+    memcpy(sig->strong_sum, strong_sum, strong_len);
+}
+
+rs_result rs_signature_init(rs_signature_t *sig, int magic, int block_len, int strong_len, int block_num)
+{
+    int max_strong_len;
+
+    /* Check and set default arguments. */
+    magic = magic ? magic : RS_BLAKE2_SIG_MAGIC;
+    switch (magic) {
+    case RS_BLAKE2_SIG_MAGIC:
+        max_strong_len = RS_BLAKE2_SUM_LENGTH;
+        break;
+    case RS_MD4_SIG_MAGIC:
+        max_strong_len = RS_MD4_SUM_LENGTH;
+        break;
+    default:
+        rs_error("invalid magic %#x", magic);
+        return RS_BAD_MAGIC;
+    }
+    strong_len = strong_len ? strong_len : max_strong_len;
+    if (strong_len > max_strong_len) {
+        rs_error("invalid strong_sum_len %d > %d for magic %#x", strong_len, max_strong_len, magic);
+        return RS_PARAM_ERROR;
+    }
+    /* Set attributes from args. */
+    sig->magic = magic;
+    sig->block_len = block_len;
+    sig->strong_sum_len = strong_len;
+    sig->count = 0;
+    sig->size = block_num;
+    sig->block_sigs = NULL;
+    sig->tag_table = NULL;
+    sig->targets = NULL;
+    if (block_num)
+        sig->block_sigs = rs_alloc(block_num * sizeof(rs_block_sig_t), "signature->block_sigs");
+    return RS_DONE;
+}
+
+void rs_signature_done(rs_signature_t *sig)
+{
+    free(sig->block_sigs);
+    free(sig->tag_table);
+    free(sig->targets);
+    rs_bzero(sig, sizeof(*sig));
+}
+
+rs_block_sig_t *rs_signature_add_block(rs_signature_t *sig, rs_weak_sum_t weak_sum, rs_strong_sum_t *strong_sum)
+{
+    assert(0 <= sig->count && sig->count <= sig->size);
+    /* If block_sigs is full, allocate more space. */
+    if (sig->count == sig->size) {
+        sig->size = sig->size ? sig->size * 2 : 16;
+        sig->block_sigs = rs_realloc(sig->block_sigs, sig->size * sizeof(rs_block_sig_t), "signature->block_sigs");
+    }
+    rs_block_sig_t *b = &sig->block_sigs[sig->count++];
+    rs_block_sig_init(b, sig->count, weak_sum, strong_sum, sig->strong_sum_len);
+    return b;
+}
+
 void rs_free_sumset(rs_signature_t *psums)
 {
-    if (psums->block_sigs)
-        free(psums->block_sigs);
-
-    if (psums->tag_table)
-        free(psums->tag_table);
-
-    if (psums->targets)
-        free(psums->targets);
-
-    rs_bzero(psums, sizeof *psums);
+    rs_signature_done(psums);
     free(psums);
 }
 

--- a/src/sumset.c
+++ b/src/sumset.c
@@ -32,6 +32,9 @@
 #include "util.h"
 #include "trace.h"
 
+const int RS_MD4_SUM_LENGTH = 16;
+const int RS_BLAKE2_SUM_LENGTH = 32;
+
 void rs_block_sig_init(rs_block_sig_t *sig, int i, rs_weak_sum_t weak_sum, rs_strong_sum_t *strong_sum,
                        int strong_len)
 {

--- a/src/sumset.c
+++ b/src/sumset.c
@@ -40,7 +40,7 @@ void rs_block_sig_init(rs_block_sig_t *sig, int i, rs_weak_sum_t weak_sum, rs_st
     memcpy(sig->strong_sum, strong_sum, strong_len);
 }
 
-rs_result rs_signature_init(rs_signature_t *sig, int magic, int block_len, int strong_len, int block_num)
+rs_result rs_signature_init(rs_signature_t *sig, int magic, int block_len, int strong_len, rs_long_t sig_fsize)
 {
     int max_strong_len;
 
@@ -67,12 +67,14 @@ rs_result rs_signature_init(rs_signature_t *sig, int magic, int block_len, int s
     sig->block_len = block_len;
     sig->strong_sum_len = strong_len;
     sig->count = 0;
-    sig->size = block_num;
+    /* Calculate the number of blocks if we have the signature file size. */
+    /* Magic+header is 12 bytes, each block thereafter is 4 bytes weak_sum+strong_sum_len bytes */
+    sig->size = (int)(sig_fsize ? (sig_fsize - 12) / (4 + strong_len) : 0);
     sig->block_sigs = NULL;
     sig->tag_table = NULL;
     sig->targets = NULL;
-    if (block_num)
-        sig->block_sigs = rs_alloc(block_num * sizeof(rs_block_sig_t), "signature->block_sigs");
+    if (sig->size)
+        sig->block_sigs = rs_alloc(sig->size * sizeof(rs_block_sig_t), "signature->block_sigs");
     rs_signature_check(sig);
     return RS_DONE;
 }

--- a/src/sumset.c
+++ b/src/sumset.c
@@ -56,11 +56,8 @@ rs_sumset_dump(rs_signature_t const *sums)
         char        strong_hex[RS_MAX_STRONG_SUM_LENGTH * 3];
     
         rs_log(RS_LOG_INFO,
-                "sumset info: block_len=%d, file length=%lu, "
-                "number of chunks=%d, remainder=%d",
-                sums->block_len,
-                (unsigned long) sums->flength, sums->count,
-                sums->remainder);
+                "sumset info: magic=%x, block_len=%d, block_num=%d",
+                sums->magic, sums->block_len, sums->count);
 
         for (i = 0; i < sums->count; i++) {
                 rs_hexify(strong_hex, sums->block_sigs[i].strong_sum,

--- a/src/sumset.h
+++ b/src/sumset.h
@@ -49,8 +49,7 @@ void rs_block_sig_init(rs_block_sig_t *sig, int i, rs_weak_sum_t weak_sum, rs_st
 /** Signature of a whole file.
  *
  * This includes the all the block sums generated for a file and
- * datastructures for fast matching against them.
- */
+ * datastructures for fast matching against them. */
 struct rs_signature {
     int magic;                  /**> The signature magic value. */
     int block_len;              /**> The block length. */
@@ -62,8 +61,21 @@ struct rs_signature {
     rs_target_t *targets;
 };
 
-/** Initialize an rs_signature instance. */
-rs_result rs_signature_init(rs_signature_t *sig, int magic, int block_len, int strong_len, int block_num);
+/** Initialize an rs_signature instance.
+ *
+ * /param *sig the signature to initialize.
+ *
+ * /param magic the signature magic value. Must be set to a valid magic value.
+ *
+ * /param block_len the block size to use. Must be > 0.
+ *
+ * /param strong_len the strongsum size to use. Must be <= the max strongsum
+ * size for the strongsum type indicated by the magic value. Use 0 to use the
+ * recommended size for the provided magic value.
+ *
+ * /param sig_fsize signature file size to preallocate required storage for.
+ * Use 0 if size is unknown. */
+rs_result rs_signature_init(rs_signature_t *sig, int magic, int block_len, int strong_len, rs_long_t sig_fsize);
 
 /** Destroy an rs_signature instance. */
 void rs_signature_done(rs_signature_t *sig);

--- a/src/sumset.h
+++ b/src/sumset.h
@@ -32,15 +32,15 @@ typedef struct rs_target {
 /** Hashtable entry pointing at a range of rs_targets. */
 typedef struct rs_tag_table_entry {
     /* All tags between l and r inclusively are the same. */
-    int l;                      /**> Left bound of the hash tag in sorted array of targets. */
-    int r;                      /**> right bound of the hash tag in sorted array of targets. */
+    int l;                      /**< Left bound of the hash tag in sorted array of targets. */
+    int r;                      /**< right bound of the hash tag in sorted array of targets. */
 } rs_tag_table_entry_t;
 
 /** Signature of a single block. */
 typedef struct rs_block_sig {
-    int i;                      /**> Index of this block. */
-    rs_weak_sum_t weak_sum;     /**> Block's weak checksum. */
-    rs_strong_sum_t strong_sum; /**> Block's strong checksum.  */
+    int i;                      /**< Index of this block. */
+    rs_weak_sum_t weak_sum;     /**< Block's weak checksum. */
+    rs_strong_sum_t strong_sum; /**< Block's strong checksum.  */
 } rs_block_sig_t;
 
 void rs_block_sig_init(rs_block_sig_t *sig, int i, rs_weak_sum_t weak_sum, rs_strong_sum_t *strong_sum,
@@ -51,12 +51,12 @@ void rs_block_sig_init(rs_block_sig_t *sig, int i, rs_weak_sum_t weak_sum, rs_st
  * This includes the all the block sums generated for a file and
  * datastructures for fast matching against them. */
 struct rs_signature {
-    int magic;                  /**> The signature magic value. */
-    int block_len;              /**> The block length. */
-    int strong_sum_len;         /**> The block strong sum length. */
-    int count;                  /**> Total number of blocks. */
-    int size;                   /**> Total number of blocks allocated. */
-    rs_block_sig_t *block_sigs; /**> The block signatures for all blocks. */
+    int magic;                  /**< The signature magic value. */
+    int block_len;              /**< The block length. */
+    int strong_sum_len;         /**< The block strong sum length. */
+    int count;                  /**< Total number of blocks. */
+    int size;                   /**< Total number of blocks allocated. */
+    rs_block_sig_t *block_sigs; /**< The block signatures for all blocks. */
     rs_tag_table_entry_t *tag_table;
     rs_target_t *targets;
 };

--- a/src/sumset.h
+++ b/src/sumset.h
@@ -20,25 +20,24 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-
 /* Description of the match described by a signature. */
 typedef struct rs_target {
-    unsigned short  t;
-    int             i;
+    unsigned short t;
+    int i;
 } rs_target_t;
 
 /* Hashtable entry pointing at a range of rs_targets. */
 typedef struct rs_tag_table_entry {
-    int l; // left bound of the hash tag in sorted array of targets
-    int r; // right bound of the hash tag in sorted array of targets
-    // all tags between l and r inclusively are the same
-} rs_tag_table_entry_t ;
+    /* All tags between l and r inclusively are the same. */
+    int l;                      /* Left bound of the hash tag in sorted array of targets. */
+    int r;                      /* right bound of the hash tag in sorted array of targets. */
+} rs_tag_table_entry_t;
 
 /* Signature of a single block. */
 typedef struct rs_block_sig {
-    int             i;		/* index of this chunk */
-    rs_weak_sum_t   weak_sum;	/* weak checksum */
-    rs_strong_sum_t strong_sum;	/* strong checksum  */
+    int i;                      /* Index of this block. */
+    rs_weak_sum_t weak_sum;     /* Block's weak checksum. */
+    rs_strong_sum_t strong_sum; /* Block's strong checksum.  */
 } rs_block_sig_t;
 
 /*
@@ -47,11 +46,11 @@ typedef struct rs_block_sig {
  * search.
  */
 struct rs_signature {
-    int             magic;
-    int             block_len;	/* The block length. */
-    int             strong_sum_len;  /* The block strong sum length. */
-    int             count;      /* Total number of blocks. */
-    rs_block_sig_t  *block_sigs; /* The block signatures for all blocks. */
-    rs_tag_table_entry_t	*tag_table;
-    rs_target_t     *targets;
+    int magic;                  /* The signature magic value. */
+    int block_len;              /* The block length. */
+    int strong_sum_len;         /* The block strong sum length. */
+    int count;                  /* Total number of blocks. */
+    rs_block_sig_t *block_sigs; /* The block signatures for all blocks. */
+    rs_tag_table_entry_t *tag_table;
+    rs_target_t *targets;
 };

--- a/src/sumset.h
+++ b/src/sumset.h
@@ -20,37 +20,50 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-/* Description of the match described by a signature. */
+/** Description of the match described by a signature. */
 typedef struct rs_target {
     unsigned short t;
     int i;
 } rs_target_t;
 
-/* Hashtable entry pointing at a range of rs_targets. */
+/** Hashtable entry pointing at a range of rs_targets. */
 typedef struct rs_tag_table_entry {
     /* All tags between l and r inclusively are the same. */
-    int l;                      /* Left bound of the hash tag in sorted array of targets. */
-    int r;                      /* right bound of the hash tag in sorted array of targets. */
+    int l;                      /**> Left bound of the hash tag in sorted array of targets. */
+    int r;                      /**> right bound of the hash tag in sorted array of targets. */
 } rs_tag_table_entry_t;
 
-/* Signature of a single block. */
+/** Signature of a single block. */
 typedef struct rs_block_sig {
-    int i;                      /* Index of this block. */
-    rs_weak_sum_t weak_sum;     /* Block's weak checksum. */
-    rs_strong_sum_t strong_sum; /* Block's strong checksum.  */
+    int i;                      /**> Index of this block. */
+    rs_weak_sum_t weak_sum;     /**> Block's weak checksum. */
+    rs_strong_sum_t strong_sum; /**> Block's strong checksum.  */
 } rs_block_sig_t;
 
-/*
- * This structure describes all the sums generated for an instance of
- * a file.  It incorporates some redundancy to make it easier to
- * search.
+void rs_block_sig_init(rs_block_sig_t *sig, int i, rs_weak_sum_t weak_sum, rs_strong_sum_t *strong_sum,
+                       int strong_len);
+
+/** Signature of a whole file.
+ *
+ * This includes the all the block sums generated for a file and
+ * datastructures for fast matching against them.
  */
 struct rs_signature {
-    int magic;                  /* The signature magic value. */
-    int block_len;              /* The block length. */
-    int strong_sum_len;         /* The block strong sum length. */
-    int count;                  /* Total number of blocks. */
-    rs_block_sig_t *block_sigs; /* The block signatures for all blocks. */
+    int magic;                  /**> The signature magic value. */
+    int block_len;              /**> The block length. */
+    int strong_sum_len;         /**> The block strong sum length. */
+    int count;                  /**> Total number of blocks. */
+    int size;                   /**> Total number of blocks allocated. */
+    rs_block_sig_t *block_sigs; /**> The block signatures for all blocks. */
     rs_tag_table_entry_t *tag_table;
     rs_target_t *targets;
 };
+
+/** Initialize an rs_signature instance. */
+rs_result rs_signature_init(rs_signature_t *sig, int magic, int block_len, int strong_len, int block_num);
+
+/** Destroy an rs_signature instance. */
+void rs_signature_done(rs_signature_t *sig);
+
+/** Add a block to an rs_signature instance. */
+rs_block_sig_t *rs_signature_add_block(rs_signature_t *sig, rs_weak_sum_t weak_sum, rs_strong_sum_t *strong_sum);

--- a/src/sumset.h
+++ b/src/sumset.h
@@ -1,20 +1,20 @@
 /*= -*- c-basic-offset: 4; indent-tabs-mode: nil; -*-
  *
  * librsync -- the library for network deltas
- * 
+ *
  * Copyright (C) 1999, 2000, 2001 by Martin Pool <mbp@sourcefrog.net>
  * Copyright (C) 1999 by Andrew Tridgell <tridge@samba.org>
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * as published by the Free Software Foundation; either version 2.1 of
  * the License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
@@ -50,15 +50,13 @@ typedef struct rs_tag_table_entry {
  * search.
  */
 struct rs_signature {
-    rs_long_t       flength;	/* total file length */
-    int             count;      /* how many chunks */
-    int             remainder;	/* flength % block_length */
+    int             magic;
     int             block_len;	/* block_length */
     int             strong_sum_len;
+    int             count;      /* how many blocks */
     rs_block_sig_t  *block_sigs; /* points to info for each chunk */
     rs_tag_table_entry_t	*tag_table;
     rs_target_t     *targets;
-    int             magic;
 };
 
 

--- a/src/sumset.h
+++ b/src/sumset.h
@@ -63,17 +63,17 @@ struct rs_signature {
 
 /** Initialize an rs_signature instance.
  *
- * /param *sig the signature to initialize.
+ * \param *sig the signature to initialize.
  *
- * /param magic the signature magic value. Must be set to a valid magic value.
+ * \param magic the signature magic value. Must be set to a valid magic value.
  *
- * /param block_len the block size to use. Must be > 0.
+ * \param block_len the block size to use. Must be > 0.
  *
- * /param strong_len the strongsum size to use. Must be <= the max strongsum
+ * \param strong_len the strongsum size to use. Must be <= the max strongsum
  * size for the strongsum type indicated by the magic value. Use 0 to use the
  * recommended size for the provided magic value.
  *
- * /param sig_fsize signature file size to preallocate required storage for.
+ * \param sig_fsize signature file size to preallocate required storage for.
  * Use 0 if size is unknown. */
 rs_result rs_signature_init(rs_signature_t *sig, int magic, int block_len, int strong_len, rs_long_t sig_fsize);
 
@@ -88,11 +88,11 @@ rs_block_sig_t *rs_signature_add_block(rs_signature_t *sig, rs_weak_sum_t weak_s
  * We don't use a static inline function here so that assert failure
  * output points at where rs_signature_check() was called from. */
 #define rs_signature_check(sig) do {\
-    assert((sig->magic == RS_BLAKE2_SIG_MAGIC && sig->strong_sum_len <= RS_BLAKE2_SUM_LENGTH)\
-           || (sig->magic == RS_MD4_SIG_MAGIC && sig->strong_sum_len <= RS_MD4_SUM_LENGTH));\
-    assert(0 < sig->block_len);\
-    assert(0 < sig->strong_sum_len && sig->strong_sum_len <= RS_MAX_STRONG_SUM_LENGTH);\
-    assert(0 <= sig->count && sig->count <= sig->size);\
+    assert(((sig)->magic == RS_BLAKE2_SIG_MAGIC && (sig)->strong_sum_len <= RS_BLAKE2_SUM_LENGTH)\
+           || ((sig)->magic == RS_MD4_SIG_MAGIC && (sig)->strong_sum_len <= RS_MD4_SUM_LENGTH));\
+    assert(0 < (sig)->block_len);\
+    assert(0 < (sig)->strong_sum_len && (sig)->strong_sum_len <= RS_MAX_STRONG_SUM_LENGTH);\
+    assert(0 <= (sig)->count && (sig)->count <= (sig)->size);\
 } while (0)
 
 /** Calculate the strong sum of a buffer. */

--- a/src/sumset.h
+++ b/src/sumset.h
@@ -21,28 +21,25 @@
  */
 
 
-/*
- * TODO: These structures are not terribly useful.  Perhaps we need a
- * splay tree or something that will let us smoothly grow as data is
- * read in.
- */
-
-
-/**
- * \brief Description of the match described by a signature.
- */
+/* Description of the match described by a signature. */
 typedef struct rs_target {
     unsigned short  t;
     int             i;
 } rs_target_t;
 
-typedef struct rs_block_sig rs_block_sig_t;
-
+/* Hashtable entry pointing at a range of rs_targets. */
 typedef struct rs_tag_table_entry {
     int l; // left bound of the hash tag in sorted array of targets
     int r; // right bound of the hash tag in sorted array of targets
     // all tags between l and r inclusively are the same
 } rs_tag_table_entry_t ;
+
+/* Signature of a single block. */
+typedef struct rs_block_sig {
+    int             i;		/* index of this chunk */
+    rs_weak_sum_t   weak_sum;	/* weak checksum */
+    rs_strong_sum_t strong_sum;	/* strong checksum  */
+} rs_block_sig_t;
 
 /*
  * This structure describes all the sums generated for an instance of
@@ -51,21 +48,10 @@ typedef struct rs_tag_table_entry {
  */
 struct rs_signature {
     int             magic;
-    int             block_len;	/* block_length */
-    int             strong_sum_len;
-    int             count;      /* how many blocks */
-    rs_block_sig_t  *block_sigs; /* points to info for each chunk */
+    int             block_len;	/* The block length. */
+    int             strong_sum_len;  /* The block strong sum length. */
+    int             count;      /* Total number of blocks. */
+    rs_block_sig_t  *block_sigs; /* The block signatures for all blocks. */
     rs_tag_table_entry_t	*tag_table;
     rs_target_t     *targets;
-};
-
-
-/*
- * All blocks are the same length in the current algorithm except for
- * the last block which may be short.
- */
-struct rs_block_sig {
-    int             i;		/* index of this chunk */
-    rs_weak_sum_t   weak_sum;	/* simple checksum */
-    rs_strong_sum_t strong_sum;	/* checksum  */
 };

--- a/src/util.c
+++ b/src/util.c
@@ -19,11 +19,9 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-
-                                /* 
-                                 | On heroin, I have all the answers.
+                                /*
+                                 * On heroin, I have all the answers.
                                  */
-
 
 #include "config.h"
 #include <sys/types.h>
@@ -37,17 +35,34 @@
 #include "util.h"
 #include "trace.h"
 
-void
-rs_bzero(void *buf, size_t size)
+void rs_bzero(void *buf, size_t size)
 {
     memset(buf, 0, size);
 }
 
-
-void *
-rs_alloc_struct0(size_t size, char const *name)
+void *rs_alloc(size_t size, char const *name)
 {
-    void           *p;
+    void *p;
+
+    if (!(p = malloc(size))) {
+        rs_fatal("couldn't allocate instance of %s", name);
+    }
+    return p;
+}
+
+void *rs_realloc(void *ptr, size_t size, char const *name)
+{
+    void *p;
+
+    if (!(p = realloc(ptr, size))) {
+        rs_fatal("couldn't reallocate instance of %s", name);
+    }
+    return p;
+}
+
+void *rs_alloc_struct0(size_t size, char const *name)
+{
+    void *p;
 
     if (!(p = malloc(size))) {
         rs_fatal("couldn't allocate instance of %s", name);
@@ -56,43 +71,27 @@ rs_alloc_struct0(size_t size, char const *name)
     return p;
 }
 
-
-
-void *
-rs_alloc(size_t size, char const *name)
-{
-    void           *p;
-
-    if (!(p = malloc(size))) {
-        rs_fatal("couldn't allocate instance of %s", name);
-    }
-
-    return p;
-}
-
-
 #ifdef HAVE_FSTATI64
 #  ifdef stat
-#   undef stat
+#    undef stat
 #  endif
 #  define stat _stati64
 #  ifdef fstat
-#   undef fstat
+#    undef fstat
 #  endif
 #  define fstat(f,s) _fstati64((f), (s))
 #elif defined HAVE_FSTAT64
 #  ifdef stat
-#   undef stat
+#    undef stat
 #  endif
 #  define stat stat64
 #  ifdef fstat
-#   undef fstat
+#    undef fstat
 #  endif
 #  define fstat(f,s) fstat64((f), (s))
 #endif
 
-void
-rs_get_filesize(FILE *f, rs_long_t *size)
+void rs_get_filesize(FILE * f, rs_long_t *size)
 {
     struct stat st;
     if (size && (fstat(fileno(f), &st) == 0) && (S_ISREG(st.st_mode))) {

--- a/src/util.c
+++ b/src/util.c
@@ -19,9 +19,11 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-                                /*
-                                 * On heroin, I have all the answers.
+
+                                /* 
+                                 | On heroin, I have all the answers.
                                  */
+
 
 #include "config.h"
 #include <sys/types.h>
@@ -35,34 +37,17 @@
 #include "util.h"
 #include "trace.h"
 
-void rs_bzero(void *buf, size_t size)
+void
+rs_bzero(void *buf, size_t size)
 {
     memset(buf, 0, size);
 }
 
-void *rs_alloc(size_t size, char const *name)
+
+void *
+rs_alloc_struct0(size_t size, char const *name)
 {
-    void *p;
-
-    if (!(p = malloc(size))) {
-        rs_fatal("couldn't allocate instance of %s", name);
-    }
-    return p;
-}
-
-void *rs_realloc(void *ptr, size_t size, char const *name)
-{
-    void *p;
-
-    if (!(p = realloc(ptr, size))) {
-        rs_fatal("couldn't reallocate instance of %s", name);
-    }
-    return p;
-}
-
-void *rs_alloc_struct0(size_t size, char const *name)
-{
-    void *p;
+    void           *p;
 
     if (!(p = malloc(size))) {
         rs_fatal("couldn't allocate instance of %s", name);
@@ -71,27 +56,55 @@ void *rs_alloc_struct0(size_t size, char const *name)
     return p;
 }
 
+
+
+void *
+rs_alloc(size_t size, char const *name)
+{
+    void           *p;
+
+    if (!(p = malloc(size))) {
+        rs_fatal("couldn't allocate instance of %s", name);
+    }
+
+    return p;
+}
+
+
+void *
+rs_realloc(void *ptr, size_t size, char const *name)
+{
+    void *p;
+
+    if (!(p = realloc(ptr, size))) {
+	rs_fatal("couldn't reallocate instance of %s", name);
+     }
+     return p;
+}
+
+
 #ifdef HAVE_FSTATI64
 #  ifdef stat
-#    undef stat
+#   undef stat
 #  endif
 #  define stat _stati64
 #  ifdef fstat
-#    undef fstat
+#   undef fstat
 #  endif
 #  define fstat(f,s) _fstati64((f), (s))
 #elif defined HAVE_FSTAT64
 #  ifdef stat
-#    undef stat
+#   undef stat
 #  endif
 #  define stat stat64
 #  ifdef fstat
-#    undef fstat
+#   undef fstat
 #  endif
 #  define fstat(f,s) fstat64((f), (s))
 #endif
 
-void rs_get_filesize(FILE * f, rs_long_t *size)
+void
+rs_get_filesize(FILE *f, rs_long_t *size)
 {
     struct stat st;
     if (size && (fstat(fileno(f), &st) == 0) && (S_ISREG(st.st_mode))) {

--- a/src/util.h
+++ b/src/util.h
@@ -20,26 +20,21 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-
-void * rs_alloc(size_t size, char const *name);
+void rs_bzero(void *buf, size_t size);
+void *rs_alloc(size_t size, char const *name);
+void *rs_realloc(void *ptr, size_t size, char const *name);
 void *rs_alloc_struct0(size_t size, char const *name);
 
-void rs_bzero(void *buf, size_t size);
+void rs_get_filesize(FILE * f, rs_long_t *size);
 
-void rs_get_filesize(FILE *f, rs_long_t *size);
-
-
-/*
- * Allocate and zero-fill an instance of TYPE.
- */
+/* Allocate and zero-fill an instance of TYPE. */
 #define rs_alloc_struct(type)				\
         ((type *) rs_alloc_struct0(sizeof(type), #type))
-
 
 #ifdef __GNUC__
 #  define UNUSED(x) x __attribute__((unused))
 #elif defined(__LCLINT__) || defined(S_SPLINT_S)
 #  define UNUSED(x) /*@unused@*/ x
-#else				/* !__GNUC__ && !__LCLINT__ */
+#else                           /* !__GNUC__ && !__LCLINT__ */
 #  define UNUSED(x) x
-#endif				/* !__GNUC__ && !__LCLINT__ */
+#endif                          /* !__GNUC__ && !__LCLINT__ */

--- a/src/util.h
+++ b/src/util.h
@@ -20,21 +20,27 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-void rs_bzero(void *buf, size_t size);
-void *rs_alloc(size_t size, char const *name);
-void *rs_realloc(void *ptr, size_t size, char const *name);
+
+void * rs_alloc(size_t size, char const *name);
+void * rs_realloc(void *ptr, size_t size, char const *name);
 void *rs_alloc_struct0(size_t size, char const *name);
 
-void rs_get_filesize(FILE * f, rs_long_t *size);
+void rs_bzero(void *buf, size_t size);
 
-/* Allocate and zero-fill an instance of TYPE. */
+void rs_get_filesize(FILE *f, rs_long_t *size);
+
+
+/*
+ * Allocate and zero-fill an instance of TYPE.
+ */
 #define rs_alloc_struct(type)				\
         ((type *) rs_alloc_struct0(sizeof(type), #type))
+
 
 #ifdef __GNUC__
 #  define UNUSED(x) x __attribute__((unused))
 #elif defined(__LCLINT__) || defined(S_SPLINT_S)
 #  define UNUSED(x) /*@unused@*/ x
-#else                           /* !__GNUC__ && !__LCLINT__ */
+#else				/* !__GNUC__ && !__LCLINT__ */
 #  define UNUSED(x) x
-#endif                          /* !__GNUC__ && !__LCLINT__ */
+#endif				/* !__GNUC__ && !__LCLINT__ */

--- a/src/whole.c
+++ b/src/whole.c
@@ -119,7 +119,7 @@ rs_loadsig_file(FILE *sig_file, rs_signature_t **sumset, rs_stats_t *stats)
     job = rs_loadsig_begin(sumset);
 
     /* Estimate a number of signatures by file size */
-    rs_get_filesize(sig_file, &job->sig_file_bytes);
+    rs_get_filesize(sig_file, &job->sig_fsize);
 
     r = rs_whole_run(job, sig_file, NULL);
     if (stats)

--- a/tests/sumset_test.c
+++ b/tests/sumset_test.c
@@ -1,0 +1,111 @@
+/*= -*- c-basic-offset: 4; indent-tabs-mode: nil; -*-
+ *
+ * rollsum_test -- tests for the librsync rolling checksum.
+ *
+ * Copyright (C) 2003 by Donovan Baarda <abo@minkirri.apana.org.au>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#include "config.h"
+#include <string.h>
+#include <assert.h>
+#include "librsync.h"
+#include "sumset.h"
+
+/* Test driver for sumset.c. */
+int main(int argc, char **argv)
+{
+    rs_signature_t sig;
+    rs_result res;
+    rs_weak_sum_t weak = 0x12345678;
+    rs_strong_sum_t strong = "ABCDEF";
+    int i;
+    unsigned char buf[256];
+
+    /* Initialize test buffer. */
+    for (i = 0; i < 256; i++)
+        buf[i] = i;
+
+    /* Test rs_signature_init() */
+    /* Default zero magic. */
+    res = rs_signature_init(&sig, 0, 16, 6, 0);
+    assert(res == RS_DONE);
+    assert(sig.magic == RS_BLAKE2_SIG_MAGIC);
+    assert(sig.block_len == 16);
+    assert(sig.strong_sum_len == 6);
+    assert(sig.count == 0);
+    assert(sig.size == 0);
+    assert(sig.block_sigs == NULL);
+    assert(sig.tag_table == NULL);
+    assert(sig.targets == NULL);
+
+    /* Blake2 magic. */
+    res = rs_signature_init(&sig, RS_BLAKE2_SIG_MAGIC, 16, 6, 0);
+    assert(res == RS_DONE);
+    assert(sig.magic == RS_BLAKE2_SIG_MAGIC);
+
+    /* MD4 magic. */
+    res = rs_signature_init(&sig, RS_MD4_SIG_MAGIC, 16, 6, 0);
+    assert(res == RS_DONE);
+    assert(sig.magic == RS_MD4_SIG_MAGIC);
+
+    /* Bad magic. */
+    res = rs_signature_init(&sig, 1, 16, 6, 0);
+    assert(res == RS_BAD_MAGIC);
+
+    /* Bad strong_sum_len. */
+    res = rs_signature_init(&sig, RS_MD4_SIG_MAGIC, 16, 17, 0);
+    assert(res == RS_PARAM_ERROR);
+
+    /* With sig_fsize provided. */
+    res = rs_signature_init(&sig, 0, 16, 6, 92);
+    assert(res == RS_DONE);
+    assert(sig.magic == RS_BLAKE2_SIG_MAGIC);
+    assert(sig.block_len == 16);
+    assert(sig.strong_sum_len == 6);
+    assert(sig.count == 0);
+    assert(sig.size == 8);
+    assert(sig.block_sigs != NULL);
+    assert(sig.tag_table == NULL);
+    assert(sig.targets == NULL);
+
+    /* Test rs_signature_done(). */
+    rs_signature_done(&sig);
+    assert(sig.size == 0);
+    assert(sig.block_sigs == NULL);
+
+    /* Test rs_signature_calc_strong_sum(). */
+    res = rs_signature_init(&sig, RS_MD4_SIG_MAGIC, 16, 6, 0);
+    rs_signature_calc_strong_sum(&sig, &buf, 256, &strong);
+    assert(memcmp(&strong, "\x29\x8a\x05\xbc\x50\x6e", 6) == 0);
+
+    res = rs_signature_init(&sig, RS_BLAKE2_SIG_MAGIC, 16, 6, 0);
+    rs_signature_calc_strong_sum(&sig, &buf, 256, &strong);
+    assert(memcmp(&strong, "\x39\xa7\xeb\x9f\xed\xc1", 6) == 0);
+
+    /* Test rs_signature_add_block() */
+    res = rs_signature_init(&sig, 0, 16, 6, 0);
+    rs_signature_add_block(&sig, weak, &strong);
+    assert(sig.count == 1);
+    assert(sig.size == 16);
+    assert(sig.block_sigs != NULL);
+    assert(sig.block_sigs[0].i == 1);
+    assert(sig.block_sigs[0].weak_sum == 0x12345678);
+    assert(memcmp(sig.block_sigs[0].strong_sum, &strong, 6) == 0);
+    rs_signature_done(&sig);
+
+    return 0;
+}

--- a/tests/triple.test
+++ b/tests/triple.test
@@ -31,18 +31,18 @@ do
         do
             for hashopt in -Hmd4 -Hblake2
             do
-                run_test ../rdiff $debug $hashopt -f -I$buf -O$buf signature $old $tmpdir/sig
-                run_test ../rdiff $debug $hashopt -f -I$buf -O$buf delta $tmpdir/sig $new $tmpdir/delta
-                run_test ../rdiff $debug $hashopt -f -I$buf -O$buf patch $old $tmpdir/delta $tmpdir/new
+                run_test $bindir/rdiff $debug $hashopt -f -I$buf -O$buf signature $old $tmpdir/sig
+                run_test $bindir/rdiff $debug $hashopt -f -I$buf -O$buf delta $tmpdir/sig $new $tmpdir/delta
+                run_test $bindir/rdiff $debug $hashopt -f -I$buf -O$buf patch $old $tmpdir/delta $tmpdir/new
 
                 check_compare $new $tmpdir/new "triple -I$buf -O$buf $old $new"
 
                 # Run tests again and check if reading and writing to pipes works
                 :> $tmpdir/new
-                cat $old | run_test ../rdiff $debug $hashopt -I$buf -O$buf signature > $tmpdir/sig
+                cat $old | run_test $bindir/rdiff $debug $hashopt -I$buf -O$buf signature > $tmpdir/sig
                 # this test pipes signature instead of $new so that signature memory preallocation is tested
-                cat $tmpdir/sig | run_test ../rdiff $debug $hashopt -I$buf -O$buf delta - $new > $tmpdir/delta
-                cat $tmpdir/delta | run_test ../rdiff $debug $hashopt -I$buf -O$buf patch $old > $tmpdir/new
+                cat $tmpdir/sig | run_test $bindir/rdiff $debug $hashopt -I$buf -O$buf delta - $new > $tmpdir/delta
+                cat $tmpdir/delta | run_test $bindir/rdiff $debug $hashopt -I$buf -O$buf patch $old > $tmpdir/new
 
                 check_compare $new $tmpdir/new "triple -I$buf -O$buf $old $new"
             done


### PR DESCRIPTION
This makes `rs_signature_t` more like a class with methods for interacting with it.

This removes some redundant code that duplicated things like signature sanity checking and strongsum algorithm selection based on the signature magic. This makes the sanity checking way more consistent and will make it easier to add different checksum and rollsum algorithms or hashtable implementations.

Removes `job->estimated_signature_count` and renames `job->sig_file_bytes` to `job->sig_fsize`. The estimated block count is is redundant with file size for estimating the number of blocks to pre-allocate. Moves the calculation of block count into `rs_signature_init()` method which takes an `sig_fsize` argument. Note this is also not exposed at the API, so can only be used for whole file operations.

Changes the signature block allocator to fall back when `sig_fsize` is not available to O(ln(N)) allocations instead of O(N) by doubling the allocated size each time. This should speed up applications loading signatures using the streaming API which cannot provide `job->sig_fsize`.

Adds `rs_realloc()` function to `util.h` that does realloc or die to match rs_alloc(). This is used by the signature for resizing the allocated block_sums.

Adds `job->job_owns_sig` attribute used to indicate when the signature should be destroyed with the job. This is used by mksum.c which creates a signature but never passes it to the client. Note changing mksum.c to return the signature to the client would enable direct basis->delta calculations without having to save/load the signature.

Removes job's redundant `magic`, `block_len`, and `strong_sum_len` attributes and makes everything use the signature's equivalent attributes instead. Replaces them in job with `sig_magic`, `sig_block_len`, and `sig_strong_len` attributes that are used only for initializing the signature in mksum.c and loadsums.c. The new names are to avoid confusion between the job and signatures attributes.

Fixed "slack deltas" support in delta.c so that slack deltas are used when doing a delta operation with a NULL signature. Tidied up the code supporting slack deltas a bit.

It makes all of the job type's workflows consistent so that `rs_*_begin()` operations always return a valid `rs_job_t` instance and can never fail except by assertions that should never happen in a valid program. Failures instead are always reported via iteration callbacks returning error results. Note that previously some `rs_*_begin()` operations had fatal errors or could return `NULL`, but we were not checking for this where we call them in `whole.c`.

I also did a bit of indent tidying along the way that I decided to revert at the end to minimize the final diffs. Sorry for the commit noise this causes. I think we should standardize on a reformatting tool and style (indent? clang-format?) and clean it all up, but that's something for another pull request.