### PR TITLE
Optimize and refine hashtable.

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -427,7 +427,7 @@ EXTRACT_PACKAGE        = NO
 # included in the documentation.
 # The default value is: NO.
 
-EXTRACT_STATIC         = NO
+EXTRACT_STATIC         = YES
 
 # If the EXTRACT_LOCAL_CLASSES tag is set to YES, classes (and structs) defined
 # locally in source files will be included in the documentation. If set to NO,
@@ -825,7 +825,7 @@ EXCLUDE_PATTERNS       =
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories use the pattern */test/*
 
-EXCLUDE_SYMBOLS        =
+EXCLUDE_SYMBOLS        = _*
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include
@@ -1945,7 +1945,7 @@ ENABLE_PREPROCESSING   = YES
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-MACRO_EXPANSION        = NO
+MACRO_EXPANSION        = YES
 
 # If the EXPAND_ONLY_PREDEF and MACRO_EXPANSION tags are both set to YES then
 # the macro expansion is limited to the macros specified with the PREDEFINED and
@@ -1953,7 +1953,7 @@ MACRO_EXPANSION        = NO
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_ONLY_PREDEF     = NO
+EXPAND_ONLY_PREDEF     = YES
 
 # If the SEARCH_INCLUDES tag is set to YES, the include files in the
 # INCLUDE_PATH will be searched if a #include is found.
@@ -1985,7 +1985,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             =
+PREDEFINED             = ENTRY=ENTRY KEY=KEY MATCH=MATCH NAME=NAME
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The
@@ -1994,7 +1994,7 @@ PREDEFINED             =
 # definition found in the source code.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_AS_DEFINED      =
+EXPAND_AS_DEFINED      = _FUNC
 
 # If the SKIP_FUNCTION_MACROS tag is set to YES then doxygen's preprocessor will
 # remove all references to function-like macros that are alone on a line, have

--- a/src/delta.c
+++ b/src/delta.c
@@ -121,7 +121,7 @@ int rs_roll_paranoia = 0;
 static rs_result rs_delta_s_scan(rs_job_t *job);
 static rs_result rs_delta_s_flush(rs_job_t *job);
 static rs_result rs_delta_s_end(rs_job_t *job);
-void rs_getinput(rs_job_t *job);
+static inline void rs_getinput(rs_job_t *job);
 static inline int rs_findmatch(rs_job_t *job, rs_long_t *match_pos, size_t *match_len);
 static inline rs_result rs_appendmatch(rs_job_t *job, rs_long_t match_pos, size_t match_len);
 static inline rs_result rs_appendmiss(rs_job_t *job, size_t miss_len);
@@ -231,7 +231,7 @@ static rs_result rs_delta_s_end(rs_job_t *job)
 }
 
 
-void rs_getinput(rs_job_t *job) {
+static inline void rs_getinput(rs_job_t *job) {
     size_t len;
 
     len=rs_scoop_total_avail(job);
@@ -251,7 +251,7 @@ void rs_getinput(rs_job_t *job) {
  * forwards beyond the block boundaries. Extending backwards would require
  * decrementing scoop_pos as appropriate.
  */
-inline int rs_findmatch(rs_job_t *job, rs_long_t *match_pos, size_t *match_len) {
+static inline int rs_findmatch(rs_job_t *job, rs_long_t *match_pos, size_t *match_len) {
     const size_t block_len = job->signature->block_len;
 
     /* calculate the weak_sum if we don't have one */
@@ -279,7 +279,7 @@ inline int rs_findmatch(rs_job_t *job, rs_long_t *match_pos, size_t *match_len) 
 /**
  * Append a match at match_pos of length match_len to the delta, extending
  * a previous match if possible, or flushing any previous miss/match. */
-inline rs_result rs_appendmatch(rs_job_t *job, rs_long_t match_pos, size_t match_len)
+static inline rs_result rs_appendmatch(rs_job_t *job, rs_long_t match_pos, size_t match_len)
 {
     rs_result result=RS_DONE;
 
@@ -310,7 +310,7 @@ inline rs_result rs_appendmatch(rs_job_t *job, rs_long_t match_pos, size_t match
  *
  * This also breaks misses up into rs_outbuflen segments to avoid accumulating
  * too much in memory. */
-inline rs_result rs_appendmiss(rs_job_t *job, size_t miss_len)
+static inline rs_result rs_appendmiss(rs_job_t *job, size_t miss_len)
 {
     rs_result result=RS_DONE;
 
@@ -327,7 +327,7 @@ inline rs_result rs_appendmiss(rs_job_t *job, size_t miss_len)
 /**
  * Flush any accumulating hit or miss, appending it to the delta.
  */
-inline rs_result rs_appendflush(rs_job_t *job)
+static inline rs_result rs_appendflush(rs_job_t *job)
 {
     /* if last is a match, emit it and reset last by resetting basis_len */
     if (job->basis_len) {
@@ -358,7 +358,7 @@ inline rs_result rs_appendflush(rs_job_t *job)
  * scoop_pos appropriately. In the future this could be used for something
  * like context compressing of miss data. Note that it also calls
  * rs_tube_catchup to output any pending output. */
-inline rs_result rs_processmatch(rs_job_t *job)
+static inline rs_result rs_processmatch(rs_job_t *job)
 {
     job->scoop_avail-=job->scoop_pos;
     job->scoop_next+=job->scoop_pos;
@@ -380,7 +380,7 @@ inline rs_result rs_processmatch(rs_job_t *job)
  *
  * In the future this could do compression of miss data before outputing
  * it. */
-inline rs_result rs_processmiss(rs_job_t *job)
+static inline rs_result rs_processmiss(rs_job_t *job)
 {
     rs_tube_copy(job, job->scoop_pos);
     job->scoop_pos=0;

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -24,11 +24,11 @@
 #include "hashtable.h"
 
 /* Open addressing works best if it can take advantage of memory caches using
- * locality for probes of adjacent buckets on collisions. So we pack the keys
- * tightly together in their own key table and avoid referencing the element
- * table and elements as much as possible. Key value zero is reserved as a
- * marker for an empty bucket to avoid checking for NULL in the element table.
- * If we do get a hash value of zero, we -1 to wrap it around to 0xffff. */
+   locality for probes of adjacent buckets on collisions. So we pack the keys
+   tightly together in their own key table and avoid referencing the element
+   table and elements as much as possible. Key value zero is reserved as a
+   marker for an empty bucket to avoid checking for NULL in the element table.
+   If we do get a hash value of zero, we -1 to wrap it around to 0xffff. */
 
 /* Use max 0.8 load factor to avoid bad open addressing performance. */
 #define HASHTABLE_LOADFACTOR_NUM 8
@@ -65,16 +65,16 @@ void hashtable_free(hashtable_t *t)
     }
 }
 
-void *hashtable_iter(hashtable_iter_t *i, hashtable_t *t)
+void *_hashtable_iter(hashtable_iter_t *i, hashtable_t *t)
 {
     assert(i != NULL);
     assert(t != NULL);
     i->htable = t;
     i->index = 0;
-    return hashtable_next(i);
+    return _hashtable_next(i);
 }
 
-void *hashtable_next(hashtable_iter_t *i)
+void *_hashtable_next(hashtable_iter_t *i)
 {
     assert(i->htable != NULL);
     assert(i->index <= i->htable->size);

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -34,7 +34,7 @@
 #define HASHTABLE_LOADFACTOR_NUM 8
 #define HASHTABLE_LOADFACTOR_DEN 10
 
-hashtable_t *hashtable_new(int size)
+hashtable_t *_hashtable_new(int size)
 {
     hashtable_t *t;
     int size2;
@@ -57,7 +57,7 @@ hashtable_t *hashtable_new(int size)
     return t;
 }
 
-void hashtable_free(hashtable_t *t)
+void _hashtable_free(hashtable_t *t)
 {
     if (t) {
         free(t->etable);

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -206,6 +206,9 @@ void *hashtable_next(hashtable_iter_t *i);
 #define MATCH KEY
 #endif
 
+#define ENTRY_T JOIN(ENTRY, _t)
+#define KEY_T JOIN(KEY, _t)
+#define MATCH_T JOIN(MATCH, _t)
 #define KEY_HASH JOIN(KEY, _hash)
 #define MATCH_CMP JOIN(MATCH, _cmp)
 
@@ -225,7 +228,7 @@ static inline unsigned mix32(unsigned int h)
  terminating at an empty bucket. */
 #define for_probe(t, k, hk, i, h) \
     const unsigned mask = t->size - 1;\
-    unsigned hk = KEY_HASH(k), i, s, h;\
+    unsigned hk = KEY_HASH((KEY_T *)k), i, s, h;\
     hk = hk ? hk : -1;\
     for (i = mix32(hk) & mask, s = 0; (h = t->ktable[i]); i = (i + ++s) & mask)
 
@@ -242,7 +245,7 @@ static inline unsigned mix32(unsigned int h)
  *
  * Returns:
  *   The added entry, or NULL if the table is full. */
-static inline void *hashtable_add(hashtable_t *t, void *e)
+static inline ENTRY_T *hashtable_add(hashtable_t *t, ENTRY_T *e)
 {
     assert(e != NULL);
     if (t->count + 1 == t->size)
@@ -271,10 +274,10 @@ static inline void *hashtable_add(hashtable_t *t, void *e)
  *
  * Returns:
  *   The first found entry, or NULL if nothing was found. */
-static inline void *hashtable_find(hashtable_t *t, void *m)
+static inline ENTRY_T *hashtable_find(hashtable_t *t, MATCH_T *m)
 {
     assert(m != NULL);
-    void *e;
+    ENTRY_T *e;
 
     stats_inc(t->find_count);
     for_probe(t, m, hm, i, he) {
@@ -293,6 +296,9 @@ static inline void *hashtable_find(hashtable_t *t, void *m)
 #undef ENTRY
 #undef KEY
 #undef MATCH
+#undef ENTRY_T
+#undef KEY_T
+#undef MATCH_T
 #undef KEY_HASH
 #undef MATCH_CMP
 #endif                          /* ENTRY */

--- a/src/sumset.c
+++ b/src/sumset.c
@@ -76,6 +76,11 @@ int rs_block_match_cmp(rs_block_match_t *match, const rs_block_sig_t *block_sig)
     return memcmp(&match->block_sig.strong_sum, &block_sig->strong_sum, match->signature->strong_sum_len);
 }
 
+/* Instantiate hashtable for rs_block_sig and rs_block_match. */
+#define ENTRY rs_block_sig
+#define MATCH rs_block_match
+#include "hashtable.c"
+
 /* Get the size of a packed rs_block_sig_t. */
 static inline size_t rs_block_sig_size(const rs_signature_t *sig)
 {
@@ -190,7 +195,7 @@ rs_result rs_build_hash_table(rs_signature_t *sig)
     int i;
 
     rs_signature_check(sig);
-    sig->hashtable = hashtable_new(sig->count, (hash_f)&rs_block_sig_hash, (cmp_f)&rs_block_match_cmp);
+    sig->hashtable = hashtable_new(sig->count);
     if (!sig->hashtable)
         return RS_MEM_ERROR;
     for (i = 0; i < sig->count; i++)

--- a/src/sumset.c
+++ b/src/sumset.c
@@ -36,7 +36,7 @@
 const int RS_MD4_SUM_LENGTH = 16;
 const int RS_BLAKE2_SUM_LENGTH = 32;
 
-void rs_block_sig_init(rs_block_sig_t *sig, rs_weak_sum_t weak_sum, rs_strong_sum_t *strong_sum, int strong_len)
+static void rs_block_sig_init(rs_block_sig_t *sig, rs_weak_sum_t weak_sum, rs_strong_sum_t *strong_sum, int strong_len)
 {
     sig->weak_sum = weak_sum;
     memcpy(sig->strong_sum, strong_sum, strong_len);
@@ -54,8 +54,8 @@ typedef struct rs_block_match {
     size_t len;
 } rs_block_match_t;
 
-void rs_block_match_init(rs_block_match_t *match, rs_signature_t *sig, rs_weak_sum_t weak_sum, const void *buf,
-                         size_t len)
+static void rs_block_match_init(rs_block_match_t *match, rs_signature_t *sig, rs_weak_sum_t weak_sum, const void *buf,
+				size_t len)
 {
     match->block_sig.weak_sum = weak_sum;
     match->signature = sig;

--- a/src/sumset.c
+++ b/src/sumset.c
@@ -42,7 +42,7 @@ void rs_block_sig_init(rs_block_sig_t *sig, rs_weak_sum_t weak_sum, rs_strong_su
     memcpy(sig->strong_sum, strong_sum, strong_len);
 }
 
-unsigned rs_block_sig_hash(const rs_block_sig_t *sig)
+static inline unsigned rs_block_sig_hash(const rs_block_sig_t *sig)
 {
     return (unsigned)sig->weak_sum;
 }
@@ -63,7 +63,7 @@ void rs_block_match_init(rs_block_match_t *match, rs_signature_t *sig, rs_weak_s
     match->len = len;
 }
 
-int rs_block_match_cmp(rs_block_match_t *match, const rs_block_sig_t *block_sig)
+static inline int rs_block_match_cmp(rs_block_match_t *match, const rs_block_sig_t *block_sig)
 {
     /* If buf is not NULL, the strong sum is yet to be calculated. */
     if (match->buf) {

--- a/src/sumset.c
+++ b/src/sumset.c
@@ -79,6 +79,7 @@ static inline int rs_block_match_cmp(rs_block_match_t *match, const rs_block_sig
 /* Instantiate hashtable for rs_block_sig and rs_block_match. */
 #define ENTRY rs_block_sig
 #define MATCH rs_block_match
+#define NAME hashtable
 #include "hashtable.h"
 
 /* Get the size of a packed rs_block_sig_t. */

--- a/src/sumset.c
+++ b/src/sumset.c
@@ -79,7 +79,7 @@ static inline int rs_block_match_cmp(rs_block_match_t *match, const rs_block_sig
 /* Instantiate hashtable for rs_block_sig and rs_block_match. */
 #define ENTRY rs_block_sig
 #define MATCH rs_block_match
-#include "hashtable.c"
+#include "hashtable.h"
 
 /* Get the size of a packed rs_block_sig_t. */
 static inline size_t rs_block_sig_size(const rs_signature_t *sig)

--- a/src/sumset.h
+++ b/src/sumset.h
@@ -30,8 +30,6 @@ typedef struct rs_block_sig {
     rs_strong_sum_t strong_sum; /**< Block's strong checksum.  */
 } rs_block_sig_t;
 
-void rs_block_sig_init(rs_block_sig_t *sig, rs_weak_sum_t weak_sum, rs_strong_sum_t *strong_sum, int strong_len);
-
 /** Signature of a whole file.
  *
  * This includes the all the block sums generated for a file and

--- a/tests/hashtable_test.c
+++ b/tests/hashtable_test.c
@@ -85,6 +85,11 @@ int match_cmp(match_t *m, const entry_t *e)
     return ans;
 }
 
+#define ENTRY entry
+#define KEY key
+#define MATCH match
+#include "hashtable.c"
+
 /* Test driver for hashtable. */
 int main(int argc, char **argv)
 {
@@ -99,11 +104,9 @@ int main(int argc, char **argv)
         entry_init(&entry[i], i);
 
     /* Test hashtable_new() */
-    t = hashtable_new(256, (hash_f)&key_hash, (cmp_f)&match_cmp);
+    t = hashtable_new(256);
     assert(t->size == 512);
     assert(t->count == 0);
-    assert(t->hash == (hash_f)&key_hash);
-    assert(t->cmp == (cmp_f)&match_cmp);
     assert(t->etable != NULL);
     assert(t->ktable != NULL);
 

--- a/tests/hashtable_test.c
+++ b/tests/hashtable_test.c
@@ -88,7 +88,7 @@ int match_cmp(match_t *m, const entry_t *e)
 #define ENTRY entry
 #define KEY key
 #define MATCH match
-#include "hashtable.c"
+#include "hashtable.h"
 
 /* Test driver for hashtable. */
 int main(int argc, char **argv)

--- a/tests/hashtable_test.c
+++ b/tests/hashtable_test.c
@@ -85,14 +85,36 @@ int match_cmp(match_t *m, const entry_t *e)
     return ans;
 }
 
+
+/* Instantiate a simple key_hashtable of keys. */
+#define ENTRY key
+#include "hashtable.h"
+
+/* Instantiate a fancy hashtable of entrys using a custom match. */
 #define ENTRY entry
 #define KEY key
 #define MATCH match
+#define NAME hashtable
 #include "hashtable.h"
 
 /* Test driver for hashtable. */
 int main(int argc, char **argv)
 {
+    /* Test key_hashtable instance. */
+    hashtable_t *kt;
+    hashtable_iter_t ki;
+    key_t k1, k2;
+
+    key_init(&k1, 1);
+    key_init(&k2, 2);
+    assert((kt = key_hashtable_new(16)) != NULL);
+    assert(key_hashtable_add(kt, &k1) == &k1);
+    assert(key_hashtable_find(kt, &k1) == &k1);
+    assert(key_hashtable_find(kt, &k2) == NULL);
+    assert(key_hashtable_iter(&ki, kt) == &k1);
+    assert(key_hashtable_next(&ki) == NULL);
+
+    /* Test hashtable instance. */
     hashtable_t *t;
     entry_t entry[256];
     entry_t e;


### PR DESCRIPTION
This shaves about 10~15% off the delta execution time, winning back the tiny performance losses we got for small files when we switched to the new open addressing hashtable.

The commit history shows the incremental refinements made. Interestingly the change from function pointers to directly referenced functions made nearly zero difference, which surprised me. The big wins were in making things static inline, with an early small win for changing the probing to a for loop that doesn't check for looping through all elements, instead relying on hashtable_add() to always leave one empty bucket.

It now is effectively a template/parametric class implemented using preprocessor macros, which is pretty much the only way to make it possible to static inline all the hashtable_find() related calls while keeping it generic enough for wider use.

I also made the comments all doxygen compatible. The doxygen docs can be previewed here;

http://minkirri.apana.org.au/~abo/librsync/hashtable_8h.html