### PR TITLE
Use fseeko64 when compiling with Mingw

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,7 +32,7 @@ NOT RELEASED YET
 
  * `popt` is only needed when `rdiff` is being built. (gulikoza)
 
- * Use `fseeko64` on mingw. (gulikoza)
+ * `fseeko64` is used when compiling with mingw.
 
  * `rdiff -s` option now shows bytes read/written and speed. (gulikoza)
 

--- a/src/buf.c
+++ b/src/buf.c
@@ -53,19 +53,13 @@
 #include "job.h"
 #include "util.h"
 
-/* Use fseeko instead of fseek for long file support if we have it.
- *
- * If provided use fseeko64 when compiling with mingw64 on Windows
- * as the size of off_t is 4 and will overflow on large files.
+/* Use fseeko64 or fseeko instead of fseek for long file support if
+ * we have it.
  */
-#if defined(__MINGW32__) && defined(HAVE_FSEEKO64)
-    #define fseek fseeko64
-#else
-    #ifdef HAVE_FSEEKO
-    #define fseek fseeko
-    #elif defined HAVE_FSEEKO64
-    #define fseek fseeko64
-    #endif
+#if defined(HAVE_FSEEKO64) && defined(HAVE_FOPEN64)
+#  define fseek fseeko64
+#elif defined(HAVE_FSEEKO)
+#  define fseek fseeko
 #endif
 
 /**

--- a/src/buf.c
+++ b/src/buf.c
@@ -53,11 +53,19 @@
 #include "job.h"
 #include "util.h"
 
-/* use fseeko instead of fseek for long file support if we have it */
-#ifdef HAVE_FSEEKO
-#define fseek fseeko
-#elif defined HAVE_FSEEKO64
-#define fseek fseeko64
+/* Use fseeko instead of fseek for long file support if we have it.
+ *
+ * If provided use fseeko64 when compiling with mingw64 on Windows
+ * as the size of off_t is 4 and will overflow on large files.
+ */
+#if defined(__MINGW32__) && defined(HAVE_FSEEKO64)
+    #define fseek fseeko64
+#else
+    #ifdef HAVE_FSEEKO
+    #define fseek fseeko
+    #elif defined HAVE_FSEEKO64
+    #define fseek fseeko64
+    #endif
 #endif
 
 /**

--- a/src/fileutil.c
+++ b/src/fileutil.c
@@ -41,6 +41,12 @@
 #include "fileutil.h"
 #include "trace.h"
 
+/* Use fopen64 instead of fopen for long file support if we have it
+ * and fseeko64.
+ */
+#if defined(HAVE_FSEEKO64) && defined(HAVE_FOPEN64)
+#  define fopen fopen64
+#endif
 
 /**
  * \brief Open a file, with special handling for `-' or unspecified


### PR DESCRIPTION
This PR defines `fseek` as `fseeko64` if it is available when compiling with Mingw - fixing an integer overflow induced error on Windows when working with large files.

The issue is that with Mingw the size of `off_t` is 4 (both when compiling for 32 and 64 bit) and both `fseeko` and `fseeko64` are defined - causing `fseek` to be defined as `fseeko`.  This leads to an overflow when the `rs_long_t` offset in `rs_file_copy_cb` is passed to `fseek`.

I noticed that the [librsync 2.0.1](https://github.com/librsync/librsync/blob/master/NEWS.md#librsync-201) section of NEWS.md says that `fseeko64` will be used for Mingw in for the 2.0.1 release.  I was wondering if we could get this change or the one planned for 2.0.1 into the master branch before then?