### PR TITLE
Improve default buffer sizes used.

### DIFF
--- a/src/delta.c
+++ b/src/delta.c
@@ -306,14 +306,15 @@ static inline rs_result rs_appendmatch(rs_job_t *job, rs_long_t match_pos, size_
  * Append a miss of length miss_len to the delta, extending a previous miss
  * if possible, or flushing any previous match.
  *
- * This also breaks misses up into rs_outbuflen segments to avoid accumulating
+ * This also breaks misses up into 4*block_len segments to avoid accumulating
  * too much in memory. */
 static inline rs_result rs_appendmiss(rs_job_t *job, size_t miss_len)
 {
+    const size_t   max_miss = 4 * job->signature->block_len;
     rs_result result=RS_DONE;
 
-    /* If last was a match, or rs_outbuflen misses, appendflush it. */
-    if (job->basis_len || (job->scoop_pos >= rs_outbuflen)) {
+    /* If last was a match, or max_miss misses, appendflush it. */
+    if (job->basis_len || (job->scoop_pos >= max_miss)) {
         result=rs_appendflush(job);
     }
     /* increment scoop_pos */

--- a/src/librsync.h
+++ b/src/librsync.h
@@ -566,8 +566,10 @@ rs_job_t *rs_patch_begin(rs_copy_cb *copy_cb, void *copy_arg);
 /**
  * Buffer sizes for file IO.
  *
- * You probably only need to change these in testing.
- */
+ * The default 0 means use the recommended buffer size for the
+ * operation being performed, any other value will override the
+ * recommended sizes. You probably only need to change these in
+ * testing. */
 extern int rs_inbuflen, rs_outbuflen;
 
 

--- a/src/whole.c
+++ b/src/whole.c
@@ -54,45 +54,46 @@
 /**
  * Whole file IO buffer sizes.
  */
-int rs_inbuflen = 16000, rs_outbuflen = 16000;
+int rs_inbuflen = 0, rs_outbuflen = 0;
 
 
-/**
- * Run a job continuously, with input to/from the two specified files.
- * The job should already be set up, and must be free by the caller
- * after return.
+/** Run a job continuously, with input to/from the two specified files.
  *
- * Buffers of ::rs_inbuflen and ::rs_outbuflen are allocated for
- * temporary storage.
+ * The job should already be set up, and must be freed by the caller
+ * after return. If rs_inbuflen or rs_outbuflen are set, they will override
+ * the inbuflen and outbuflen arguments.
  *
- * \param in_file Source of input bytes, or NULL if the input buffer
- * should not be filled.
+ * \param in_file - input file, or NULL if there is no input.
+ *
+ * \param out_file - output file, or NULL if there is no output.
+ *
+ * \param inbuflen - recommended input buffer size to use.
+ *
+ * \param outbuflen - recommended output buffer size to use.
  *
  * \return RS_DONE if the job completed, or otherwise an error result.
  */
 rs_result
-rs_whole_run(rs_job_t *job, FILE *in_file, FILE *out_file)
+rs_whole_run(rs_job_t *job, FILE *in_file, FILE *out_file, int inbuflen, int outbuflen)
 {
     rs_buffers_t    buf;
     rs_result       result;
     rs_filebuf_t    *in_fb = NULL, *out_fb = NULL;
 
+    /* Override buffer sizes if rs_inbuflen or rs_outbuflen are set. */
+    inbuflen = rs_inbuflen ? rs_inbuflen : inbuflen;
+    outbuflen = rs_outbuflen ? rs_outbuflen : outbuflen;
     if (in_file)
-        in_fb = rs_filebuf_new(in_file, rs_inbuflen);
-
+        in_fb = rs_filebuf_new(in_file, inbuflen);
     if (out_file)
-        out_fb = rs_filebuf_new(out_file, rs_outbuflen);
-
+        out_fb = rs_filebuf_new(out_file, outbuflen);
     result = rs_job_drive(job, &buf,
                           in_fb ? rs_infilebuf_fill : NULL, in_fb,
                           out_fb ? rs_outfilebuf_drain : NULL, out_fb);
-
     if (in_fb)
         rs_filebuf_free(in_fb);
-
     if (out_fb)
         rs_filebuf_free(out_fb);
-
     return result;
 }
 
@@ -108,7 +109,8 @@ rs_sig_file(FILE *old_file, FILE *sig_file, size_t new_block_len,
     rs_result       r;
 
     job = rs_sig_begin(new_block_len, strong_len, sig_magic);
-    r = rs_whole_run(job, old_file, sig_file);
+    /* Size inbuf for 4 blocks, outbuf for header + 4 blocksums. */
+    r = rs_whole_run(job, old_file, sig_file, 4 * new_block_len, 12 + 4*(4 + strong_len));
     if (stats)
         memcpy(stats, &job->stats, sizeof *stats);
     rs_job_free(job);
@@ -124,18 +126,16 @@ rs_loadsig_file(FILE *sig_file, rs_signature_t **sumset, rs_stats_t *stats)
     rs_result           r;
 
     job = rs_loadsig_begin(sumset);
-
     /* Estimate a number of signatures by file size */
     rs_get_filesize(sig_file, &job->sig_fsize);
-
-    r = rs_whole_run(job, sig_file, NULL);
+    /* Size inbuf for 1024x 16 byte blocksums. */
+    r = rs_whole_run(job, sig_file, NULL, 1024 * 16, 0);
     if (stats)
         memcpy(stats, &job->stats, sizeof *stats);
     rs_job_free(job);
 
     return r;
 }
-
 
 
 rs_result
@@ -146,17 +146,13 @@ rs_delta_file(rs_signature_t *sig, FILE *new_file, FILE *delta_file,
     rs_result           r;
 
     job = rs_delta_begin(sig);
-
-    r = rs_whole_run(job, new_file, delta_file);
-
+    /* Size inbuf for 1 block, outbuf for literal cmd + 4 blocks. */
+    r = rs_whole_run(job, new_file, delta_file, sig->block_len, 10 + 4*sig->block_len);
     if (stats)
         memcpy(stats, &job->stats, sizeof *stats);
-
     rs_job_free(job);
-
     return r;
 }
-
 
 
 rs_result rs_patch_file(FILE *basis_file, FILE *delta_file, FILE *new_file,
@@ -166,13 +162,10 @@ rs_result rs_patch_file(FILE *basis_file, FILE *delta_file, FILE *new_file,
     rs_result           r;
 
     job = rs_patch_begin(rs_file_copy_cb, basis_file);
-
-    r = rs_whole_run(job, delta_file, new_file);
-    
+    /* Default size inbuf and outbuf 64K. */
+    r = rs_whole_run(job, delta_file, new_file, 64*1024, 64*1024);
     if (stats)
         memcpy(stats, &job->stats, sizeof *stats);
-
     rs_job_free(job);
-
     return r;
 }

--- a/src/whole.h
+++ b/src/whole.h
@@ -1,23 +1,23 @@
 /*= -*- c-basic-offset: 4; indent-tabs-mode: nil; -*-
  *
  * librsync -- the library for network deltas
- * 
+ *
  * Copyright (C) 2001 by Martin Pool <mbp@sourcefrog.net>
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * as published by the Free Software Foundation; either version 2.1 of
  * the License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
 
-rs_result rs_whole_run(rs_job_t *job, FILE *in_file, FILE *out_file);
+rs_result rs_whole_run(rs_job_t *job, FILE *in_file, FILE *out_file, int inbuflen, int outbuflen);


### PR DESCRIPTION
In delta.c make the max miss output length 4*block_len  instead of rs_outbuflen so that it's independent of the whole file API buffer length arguments.

In whole.[ch] make rs_inbuflen and rs_outbuflen default to zero which means use recommended buffer sizes for the operations being performed. Make all the whole file operations use recommended buffer sizes for the operation being performed unless the rs_inbuflen or rs_outbuflen overrides have been set.

This makes rdiff use more efficient buffer sizes by default when --input-size and --output-size arguments are not set.