### PR TITLE
#include <stdio.h> in librsync.h

### DIFF
--- a/src/librsync.h
+++ b/src/librsync.h
@@ -37,6 +37,7 @@
 #define _RSYNC_H
 
 #include <sys/types.h>
+#include <stdio.h>
 #include <stdint.h>
 #include <time.h>
 


### PR DESCRIPTION
Include what you use: librsync.h uses FILE struct, but did not #include <stdio.h> to import the symbol.