### PR TITLE
Don't add duplicate blocks to the hashtable.

### DIFF
--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -234,6 +234,18 @@ static inline void _FUNC(_free)(hashtable_t *t)
     _hashtable_free(t);
 }
 
+/** Initialize hashtable stats counters.
+ *
+ * This will reset all the stats counters for the hashtable,
+ *
+ * \param *t - The hashtable to initializ stats for. */
+static inline void _FUNC(_stats_init)(hashtable_t *t)
+{
+#ifndef HASHTABLE_NSTATS
+    t->find_count = t->match_count = t->hashcmp_count = t->entrycmp_count = 0;
+#endif
+}
+
 /** Add an entry to a hashtable.
  *
  * This doesn't use MATCH_CMP() or do any checks for existing copies or

--- a/src/sumset.c
+++ b/src/sumset.c
@@ -39,7 +39,8 @@ const int RS_BLAKE2_SUM_LENGTH = 32;
 static void rs_block_sig_init(rs_block_sig_t *sig, rs_weak_sum_t weak_sum, rs_strong_sum_t *strong_sum, int strong_len)
 {
     sig->weak_sum = weak_sum;
-    memcpy(sig->strong_sum, strong_sum, strong_len);
+    if (strong_sum)
+      memcpy(sig->strong_sum, strong_sum, strong_len);
 }
 
 static inline unsigned rs_block_sig_hash(const rs_block_sig_t *sig)
@@ -54,10 +55,10 @@ typedef struct rs_block_match {
     size_t len;
 } rs_block_match_t;
 
-static void rs_block_match_init(rs_block_match_t *match, rs_signature_t *sig, rs_weak_sum_t weak_sum, const void *buf,
-				size_t len)
+static void rs_block_match_init(rs_block_match_t *match, rs_signature_t *sig, rs_weak_sum_t weak_sum,
+                                rs_strong_sum_t *strong_sum, const void *buf, size_t len)
 {
-    match->block_sig.weak_sum = weak_sum;
+    rs_block_sig_init(&match->block_sig, weak_sum, strong_sum, sig->strong_sum_len);
     match->signature = sig;
     match->buf = buf;
     match->len = len;
@@ -167,7 +168,7 @@ rs_long_t rs_signature_find_match(rs_signature_t *sig, rs_weak_sum_t weak_sum, v
     rs_block_sig_t *b;
 
     rs_signature_check(sig);
-    rs_block_match_init(&m, sig, weak_sum, buf, len);
+    rs_block_match_init(&m, sig, weak_sum, NULL, buf, len);
     if ((b = hashtable_find(sig->hashtable, &m))) {
         return (rs_long_t)rs_block_sig_idx(sig, b) * sig->block_len;
     }
@@ -193,14 +194,20 @@ void rs_signature_log_stats(rs_signature_t const *sig)
 
 rs_result rs_build_hash_table(rs_signature_t *sig)
 {
+    rs_block_match_t m;
+    rs_block_sig_t *b;
     int i;
 
     rs_signature_check(sig);
     sig->hashtable = hashtable_new(sig->count);
     if (!sig->hashtable)
         return RS_MEM_ERROR;
-    for (i = 0; i < sig->count; i++)
-        hashtable_add(sig->hashtable, rs_block_sig_ptr(sig, i));
+    for (i = 0; i < sig->count; i++) {
+        b = rs_block_sig_ptr(sig, i);
+        rs_block_match_init(&m, sig, b->weak_sum, &b->strong_sum, NULL, 0);
+        if (!hashtable_find(sig->hashtable, &m))
+            hashtable_add(sig->hashtable, b);
+    }
     return RS_DONE;
 }
 
@@ -217,7 +224,7 @@ void rs_sumset_dump(rs_signature_t const *sums)
     char strong_hex[RS_MAX_STRONG_SUM_LENGTH * 3];
 
     rs_log(RS_LOG_INFO|RS_LOG_NONAME, "sumset info: magic=%#x, block_len=%d, block_num=%d",
-	   sums->magic, sums->block_len, sums->count);
+           sums->magic, sums->block_len, sums->count);
 
     for (i = 0; i < sums->count; i++) {
         b = rs_block_sig_ptr(sums, i);

--- a/src/sumset.c
+++ b/src/sumset.c
@@ -208,6 +208,7 @@ rs_result rs_build_hash_table(rs_signature_t *sig)
         if (!hashtable_find(sig->hashtable, &m))
             hashtable_add(sig->hashtable, b);
     }
+    hashtable_stats_init(sig->hashtable);
     return RS_DONE;
 }
 

--- a/tests/hashtable_test.c
+++ b/tests/hashtable_test.c
@@ -159,8 +159,8 @@ int main(int argc, char **argv)
     hashtable_stats_init(t);
     assert(t->find_count == 0);
     assert(t->match_count == 0);
-    assert(t->hashcmp_count >= 0);
-    assert(t->entrycmp_count >= 0);
+    assert(t->hashcmp_count == 0);
+    assert(t->entrycmp_count == 0);
 #endif
 
     /* Test hashtable iterators */

--- a/tests/hashtable_test.c
+++ b/tests/hashtable_test.c
@@ -156,6 +156,11 @@ int main(int argc, char **argv)
     assert(t->match_count == 256);
     assert(t->hashcmp_count >= 256);
     assert(t->entrycmp_count >= 256);
+    hashtable_stats_init(t);
+    assert(t->find_count == 0);
+    assert(t->match_count == 0);
+    assert(t->hashcmp_count >= 0);
+    assert(t->entrycmp_count >= 0);
 #endif
 
     /* Test hashtable iterators */


### PR DESCRIPTION
A large number of duplicate blocks (eg long runs of zero) act like a DOS attack on the open addressing hashtable because they all cluster.

This means we only keep the first copy of duplicate blocks in the hashtable, and thus matches in the delta will always refer to the first matching block.

This does mean we can't return a single long match for a long sequence of identical blocks, and instead will return multiple single block matches against the first block. However, that's what we currently do anyway since we only find the first matching block in the hashtable even if there are multiple identical blocks in there.

It's also debatable if a single long match of multiple identical blocks is more efficient than multiple small matches against the first block. The delta might be a little smaller with a long match, but applying the delta gets better disk-cache hits for multiple references to the first block.