### PR TITLE
CMakeLists.txt: Don't require a C++ compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@
 # Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 
-project(librsync)
+project(librsync C)
 cmake_minimum_required(VERSION 2.6)
 
 INCLUDE(CMakeDependentOption)


### PR DESCRIPTION
By default, CMake assumes that the project is using both C and C++.  By
explicitly passing 'C' as argument of the project() macro, we tell CMake
that only C is used, which prevents CMake from erroring out if a C++
compiler doesn't exist.