### PR TITLE
Fix #32 hang for truncated input.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,21 +5,18 @@
 NOT RELEASED YET
 
  * Extensively reworked Doxygen documentation, now available at
-   http://librsync.sourcefrog.net/
-   (Martin Pool)
+   http://librsync.sourcefrog.net/ (Martin Pool)
 
  * Removed some declarations from librsync.h that were unimplemented or no
-   longer ever useful: `rs_work_options`, `rs_accum_value`.
-   Remove declaration of unimplemented `rs_mdfour_file()`.
-   (Martin Pool)
+   longer ever useful: `rs_work_options`, `rs_accum_value`. Remove
+   declaration of unimplemented `rs_mdfour_file()`. (Martin Pool)
 
  * Remove shipped `snprintf` code: no longer acutally linked after changing to
    CMake, and since it's part of C99 it should be widely available.
    (Martin Pool)
 
  * Document that Ninja (http://ninja-build.org/) is supported under CMake.
-   It's a bit faster and nicer than Make.
-   (Martin Pool)
+   It's a bit faster and nicer than Make. (Martin Pool)
 
  * `make check` (or `ninja check` etc) will now build and run the tests.
    Previously due to a CMake limitation, `make test` would only run existing
@@ -27,8 +24,7 @@ NOT RELEASED YET
    (Martin Pool, https://github.com/librsync/librsync/issues/49)
 
  * Added cmake options to exclude rdiff target and compression from build.
-   See install documentation for details.
-   Thanks to Michele Bertasi.
+   See install documentation for details. Thanks to Michele Bertasi.
 
  * `popt` is only needed when `rdiff` is being built. (gulikoza)
 
@@ -37,23 +33,47 @@ NOT RELEASED YET
    `_fstati64`), and `fileno` (`_fileno`). (dbaarda, charlievieth,
    gulikoza, marius-nicolae)
 
- * `rdiff -s` option now shows bytes read/written and speed. (gulikoza)
+ * `rdiff -s` option now shows bytes read/written and speed. (gulikoza).
+   For delta operations it also shows hashtable match statistics. (dbaarda)
 
  * Running rdiff should not overwrite existing files (signatures, deltas and
    new patched files) by default. If the destination file exists, rdiff will
-   now exit with an error. (gulikoza)
-   Add new option -f (--force) to overwrite existing files.
+   now exit with an error. Add new option -f (--force) to overwrite existing
+   files. (gulikoza)
 
- * Improve signature memory allocation (doubling size instead of
-   calling realloc for every sig block) and added support for
-   preallocation. See streaming.md job->estimated_signature_count for
-   usage when using the library. `rdiff` uses this by default if
-   possible.
+ * Improve signature memory allocation (doubling size instead of calling
+   realloc for every sig block) and added support for preallocation. See
+   streaming.md job->estimated_signature_count for usage when using the
+   library. `rdiff` uses this by default if possible. (gulikoza, dbaarda)
 
- * `stdint.h` and `inttypes.h` from C99 is now required.
+ * Significantly tidied signature handling code and testing, resulting in more
+   consistent error handling behaviour, and making it easier to plug in
+   alternative weak and strong sum implementations. Also fixed "slack delta"
+   support for delta calculation with no signature. (dbaarda)
 
- * New open addressing hashtable implementation that significantly
-   speeds up delta operations, particularly for large files.
+ * `stdint.h` and `inttypes.h` from C99 is now required. Removed redundant
+   librsync-config.h header file. (dbaarda)
+
+ * Lots of small fixes for windows platforms and building with MSVC.
+   (lasalvavida, mbrt, dbaarda)
+
+ * New open addressing hashtable implementation that significantly speeds up
+   delta operations, particularly for large files. Also fixed degenerate
+   behaviour with large number of duplicate blocks like runs of zeros
+   in sparse files. (dbaarda)
+
+ * Optional support with cmake option for using libb2 blake2 implementation.
+   Also updated included reference blake2 implementation with bug fixes
+   (dbaarda).
+
+ * Improved default values for input and output buffer sizes. The defaults are
+   now --input-size=0 and --output-size=0, which will choose recommended
+   default sizes based on the --block-size and the operation being performed.
+   (dbaarda)
+
+ * Fixed hanging for truncated input files. It will now correctly report an
+   error indicating an unexpected EOF was encountered. (dbaarda,
+   https://github.com/librsync/librsync/issues/32)
 
 ## librsync 2.0.0
 

--- a/src/mksum.c
+++ b/src/mksum.c
@@ -68,7 +68,7 @@ static rs_result rs_sig_s_header(rs_job_t *job)
     rs_result result;
 
     if ((result = rs_signature_init(sig, job->sig_magic, job->sig_block_len,
-				    job->sig_strong_len, 0)) != RS_DONE)
+                                    job->sig_strong_len, 0)) != RS_DONE)
         return result;
     rs_squirt_n4(job, sig->magic);
     rs_squirt_n4(job, sig->block_len);
@@ -122,20 +122,16 @@ rs_sig_s_generate(rs_job_t *job)
     /* must get a whole block, otherwise try again */
     len = job->signature->block_len;
     result = rs_scoop_read(job, len, &block);
-
-    /* unless we're near eof, in which case we'll accept
-     * whatever's in there */
-    if ((result == RS_BLOCKED && rs_job_input_is_ending(job))) {
+    /* If we are near EOF, get whatever is left. */
+    if (result == RS_INPUT_ENDED)
         result = rs_scoop_read_rest(job, &len, &block);
-    } else if (result == RS_INPUT_ENDED) {
+    if (result == RS_INPUT_ENDED) {
         return RS_DONE;
     } else if (result != RS_DONE) {
         rs_trace("generate stopped: %s", rs_strerror(result));
         return result;
     }
-
     rs_trace("got "FMT_SIZE" byte block", len);
-
     return rs_sig_do_block(job, block, len);
 }
 

--- a/src/tube.c
+++ b/src/tube.c
@@ -144,23 +144,17 @@ rs_tube_copy_from_scoop(rs_job_t *job)
  */
 static void rs_tube_catchup_copy(rs_job_t *job)
 {
-    rs_buffers_t *stream = job->stream;
-
     assert(job->write_len == 0);
     assert(job->copy_len > 0);
 
-    if (job->scoop_avail  && job->copy_len) {
-        /* there's still some data in the scoop, so we should use that. */
+    /* If there's data in the scoop, send that first. */
+    if (job->scoop_avail && job->copy_len) {
         rs_tube_copy_from_scoop(job);
     }
-
-    if (job->copy_len) {
-        size_t  this_copy;
-
-        this_copy = rs_buffers_copy(stream, job->copy_len);
-
+    /* If there's more to copy and we emptied the scoop, send input. */
+    if (job->copy_len && !job->scoop_avail) {
+        size_t this_copy = rs_buffers_copy(job->stream, job->copy_len);
         job->copy_len -= this_copy;
-
         rs_trace("copied "FMT_SIZE" bytes from input buffer, "FMT_LONG" remain to be copied", this_copy, job->copy_len);
     }
 }

--- a/tests/largefile.test
+++ b/tests/largefile.test
@@ -54,8 +54,8 @@ if [ ! -f "$old" ]; then
    dd bs=$blocks count=256 skip=640 if="$old" >>"$new"
 fi
 
-run_test time $bindir/rdiff $debug -f -b 1024 -S 8 -s signature $old $sig
-run_test time $bindir/rdiff $debug -f -s -I 32768 -O 32768 delta $sig $new $delta
+run_test time $bindir/rdiff $debug -f -s -b 1024 -S 8 signature $old $sig
+run_test time $bindir/rdiff $debug -f -s delta $sig $new $delta
 run_test time $bindir/rdiff $debug -f -s patch $old $delta $out
 check_compare $new $out "large files"
 true


### PR DESCRIPTION
Fix scoop.c and mksum.c handling of truncated input to correctly terminate with RS_INPUT_ENDED. This means rdiff will correctly return an error message instead of hanging for any type of operation that hits an unexpected EOF.

Add small optimizations to scoop.c and tube.c input handling.

Remove input and output size arguments for rdiff delta operation from largefile.test to test the now sane default values.

Update NEWS.md with this and all other missing changes ready for the v2.0.1 release.