### PR TITLE
Fix #33 rs_job_iter needs calling twice with eof=1.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -74,6 +74,14 @@ NOT RELEASED YET
  * Fixed hanging for truncated input files. It will now correctly report an
    error indicating an unexpected EOF was encountered. (dbaarda,
    https://github.com/librsync/librsync/issues/32)
+   
+ * Fixed #13 so that faster slack delta's are used for signatures of
+   empty files. (dbaarda,
+   https://github.com/librsync/librsync/issues/13)
+   
+ * Fixed #33 so rs_job_iter() doesn't need calling twice with eof=1.
+   Also tidied and optimized it a bit. (dbaarda,
+   https://github.com/librsync/librsync/issues/33)
 
 ## librsync 2.0.0
 

--- a/src/job.c
+++ b/src/job.c
@@ -57,8 +57,6 @@
 #include "trace.h"
 
 
-static const int rs_job_tag = 20010225;
-
 static rs_result rs_job_work(rs_job_t *job, rs_buffers_t *buffers);
 
 
@@ -69,7 +67,7 @@ rs_job_t * rs_job_new(char const *job_name, rs_result (*statefn)(rs_job_t *))
     job = rs_alloc_struct(rs_job_t);
 
     job->job_name = job_name;
-    job->dogtag = rs_job_tag;
+    job->dogtag = RS_JOB_TAG;
     job->statefn = statefn;
 
     job->stats.op = job_name;
@@ -78,12 +76,6 @@ rs_job_t * rs_job_new(char const *job_name, rs_result (*statefn)(rs_job_t *))
     rs_trace("start %s job", job_name);
 
     return job;
-}
-
-
-void rs_job_check(rs_job_t *job)
-{
-    assert(job->dogtag == rs_job_tag);
 }
 
 

--- a/src/job.h
+++ b/src/job.h
@@ -106,6 +106,15 @@ struct rs_job {
 
 rs_job_t * rs_job_new(const char *, rs_result (*statefn)(rs_job_t *));
 
-void rs_job_check(rs_job_t *job);
-
 int rs_job_input_is_ending(rs_job_t *job);
+
+/** Magic job tag number for checking jobs have been initialized. */
+#define RS_JOB_TAG 20010225
+
+/** Assert that a job is valid.
+ *
+ * We don't use a static inline function here so that assert failure output
+ * points at where rs_job_check() was called from. */
+#define rs_job_check(job) do {\
+    assert(job->dogtag == RS_JOB_TAG);\
+} while (0)


### PR DESCRIPTION
This fixes #33 and tidies up and optimizes the rs_job_iter() code.  It removes code checking for programming errors and replaces them with more extensive precondition asserts.

I also slightly cleaned and optimized rs_tube_catchup() when there is nothing to catchup.

It also includes changing rs_job_check() from a function to a #define so it gets completely optimized away when debugging is turned off and more clearly indicates where the job was bad when asserts fail.