### PR TITLE
Fix cmake/FindPOPT.cmake to mark_as_advanced POPT_INCLUDE_DIRS

### DIFF
--- a/cmake/FindPOPT.cmake
+++ b/cmake/FindPOPT.cmake
@@ -80,7 +80,7 @@ if (NOT POPT_FOUND)
 
   mark_as_advanced (
     POPT_ROOT_DIR
-    POPT_INCLUDES
+    POPT_INCLUDE_DIRS
     POPT_LIBRARIES
     )
 


### PR DESCRIPTION
Previously it was incorrectly marking the non-existent POPT_INCLUDES as advanced.

This ensures that ccmake doesn't list POPT_INCLUDE_DIRS as a configurable option.