### PR TITLE
Fix #55 remove excessive rs_fatal() calls.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -82,6 +82,12 @@ NOT RELEASED YET
  * Fixed #33 so rs_job_iter() doesn't need calling twice with eof=1.
    Also tidied and optimized it a bit. (dbaarda,
    https://github.com/librsync/librsync/issues/33)
+   
+ * Fixed #55 remove excessive rs_fatal() calls, replacing checks for
+   programming errors with assert statements. Now rs_fatal() will only
+   be called for rare unrecoverable fatal errors like malloc failures or
+   impossibly large inputs. (dbaarda,
+   https://github.com/librsync/librsync/issues/55)
 
 ## librsync 2.0.0
 

--- a/src/emit.c
+++ b/src/emit.c
@@ -63,20 +63,15 @@ void
 rs_emit_literal_cmd(rs_job_t *job, int len)
 {
     int cmd;
-    int param_len;
+    int param_len = rs_int_len(len);
 
-    switch (param_len = rs_int_len(len)) {
-    case 1:
+    if (param_len == 1)
         cmd = RS_OP_LITERAL_N1;
-        break;
-    case 2:
+    else if (param_len == 2)
         cmd = RS_OP_LITERAL_N2;
-        break;
-    case 4:
+    else {
+        assert(param_len == 4);
         cmd = RS_OP_LITERAL_N4;
-        break;
-    default:
-        rs_fatal("What?");
     }
 
     rs_trace("emit LITERAL_N%d(len=%d), cmd_byte=%#04x", param_len, len, cmd);
@@ -108,10 +103,9 @@ rs_emit_copy_cmd(rs_job_t *job, rs_long_t where, rs_long_t len)
         cmd = RS_OP_COPY_N4_N1;
     else if (where_bytes == 2)
         cmd = RS_OP_COPY_N2_N1;
-    else if (where_bytes == 1)
-        cmd = RS_OP_COPY_N1_N1;
     else {
-        rs_fatal("can't encode copy command with where_bytes=%d", where_bytes);
+        assert(where_bytes == 1);
+        cmd = RS_OP_COPY_N1_N1;
     }
 
     if (len_bytes == 1)
@@ -120,10 +114,9 @@ rs_emit_copy_cmd(rs_job_t *job, rs_long_t where, rs_long_t len)
         cmd += 1;
     else if (len_bytes == 4)
         cmd += 2;
-    else if (len_bytes == 8)
-        cmd += 3;
     else {
-        rs_fatal("can't encode copy command with len_bytes=%d", len_bytes);
+        assert(len_bytes == 8);
+        cmd += 3;
     }
 
     rs_trace("emit COPY_N%d_N%d(where="FMT_LONG", len="FMT_LONG"), cmd_byte=%#04x",


### PR DESCRIPTION
Replace unnecessary fs_fatal() calls in emit.c with asserts.
These errors could only happen if rs_int_len() was broken, so don't
need runtime checks, asserts are sufficient.

This also involved slighly changing the logic to avoid compiler
warnings when assserts are omitted for release builds, which also made
the code a little more consistent.

The only rs_fatal() calls left are for alloc failures, the tube "popping", netint.c encountering a >64bit int file offset or size, and delta.c failing a paranoid weaksum check with the rdiff --paranoia checking.