### PR TITLE
Tune max miss size for deltas.

### DIFF
--- a/src/delta.c
+++ b/src/delta.c
@@ -310,7 +310,7 @@ static inline rs_result rs_appendmatch(rs_job_t *job, rs_long_t match_pos, size_
  * too much in memory. */
 static inline rs_result rs_appendmiss(rs_job_t *job, size_t miss_len)
 {
-    const size_t   max_miss = 4 * job->signature->block_len;
+    const size_t   max_miss = 32768;  /* For 0.01% 3 command bytes overhead. */
     rs_result result=RS_DONE;
 
     /* If last was a match, or max_miss misses, appendflush it. */

--- a/tests/largefile.test
+++ b/tests/largefile.test
@@ -39,6 +39,9 @@ blocks=${2:-64K}
 datadir=${3:-$tmpdir}
 echo "DATADIR $datadir"
 
+# Use $4 to optionally specify a block size to use.
+blocksize=${4:-1024}
+
 old="$datadir/old.$blocks"
 new="$datadir/new.$blocks"
 sig="$datadir/sig.$blocks"
@@ -54,7 +57,7 @@ if [ ! -f "$old" ]; then
    dd bs=$blocks count=256 skip=640 if="$old" >>"$new"
 fi
 
-run_test time $bindir/rdiff $debug -f -s -b 1024 -S 8 signature $old $sig
+run_test time $bindir/rdiff $debug -f -s -b $blocksize -S 8 signature $old $sig
 run_test time $bindir/rdiff $debug -f -s delta $sig $new $delta
 run_test time $bindir/rdiff $debug -f -s patch $old $delta $out
 check_compare $new $out "large files"


### PR DESCRIPTION
Change the max miss size to 32K from 4*block_len.

This gives a constant 0.01% 3 command bytes overhead for misses. For small block sizes it has nearly no impact on performance but gives slightly smaller deltas. For large block sizes it gives a tiny performance increase and significantly reduced memory requirements for deltas.

Also add extra block size argument to largefile.test to make it easy to test the impact for different block sizes.

This had less performance impact than I expected, but it is a little win.
