### PR TITLE
Avoid check_c_source_runs() when cross compiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,9 +108,14 @@ check_type_size ( "unsigned int" SIZEOF_UNSIGNED_INT )
 check_type_size ( "unsigned long" SIZEOF_UNSIGNED_LONG )
 check_type_size ( "unsigned short" SIZEOF_UNSIGNED_SHORT )
 
-# Check for printf "%zu" size_t formating support.
-include(CheckCSourceRuns)
-check_c_source_runs("#include <stdio.h>\nint main(){char o[8];sprintf(o, \"%zu\", (size_t)7);return o[0] != '7';}" HAVE_PRINTF_Z)
+# Check for printf "%zu" size_t formatting support.
+if(CMAKE_CROSSCOMPILING)
+  set(HAVE_PRINTF_Z ON)
+  message (STATUS "Cross compiling - assuming printf \"%zu\" size_t formatting support")
+else()
+  include(CheckCSourceRuns)
+  check_c_source_runs("#include <stdio.h>\nint main(){char o[8];sprintf(o, \"%zu\", (size_t)7);return o[0] != '7';}" HAVE_PRINTF_Z)
+endif()
 
 include (TestBigEndian)
 TEST_BIG_ENDIAN(WORDS_BIGENDIAN)


### PR DESCRIPTION
Using check_c_source_runs() causes the build to fail when cross compiling. In that case we cannot check for printf "%zu" size_t formating support by executing a binary - instead assume it.

This should be safe as AFAIK only MS Visual Studio versions prior to VS2013 doesn't support it, and it's unlikely that someone should be using an old Visual Studio to cross compile librsync.