### PR TITLE
Fix #135 memory alignment for rs_block_sum_t instances.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@
 
 NOT RELEASED YET
 
+ * Improve CMake install paths configuration (wRAR, #133) and platform support
+   checking when cross-compiling (fornwall, #136).
+
+ * Fix Unaligned memory access for rs_block_sig_init() (dbaarda, #135).
+
 ## librsync 2.0.1
 
 Released 2017-10-17

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,10 +4,13 @@
 
 NOT RELEASED YET
 
- * Improve CMake install paths configuration (wRAR, #133) and platform support
-   checking when cross-compiling (fornwall, #136).
+ * Improve CMake install paths configuration (wRAR,
+   https://github.com/librsync/librsync/pull/133) and platform support
+   checking when cross-compiling (fornwall,
+   https://github.com/librsync/librsync/pull/136).
 
- * Fix Unaligned memory access for rs_block_sig_init() (dbaarda, #135).
+ * Fix Unaligned memory access for rs_block_sig_init() (dbaarda,
+   https://github.com/librsync/librsync/issues/135).
 
 ## librsync 2.0.1
 

--- a/src/sumset.c
+++ b/src/sumset.c
@@ -86,7 +86,9 @@ static inline int rs_block_match_cmp(rs_block_match_t *match, const rs_block_sig
 /* Get the size of a packed rs_block_sig_t. */
 static inline size_t rs_block_sig_size(const rs_signature_t *sig)
 {
-    return offsetof(rs_block_sig_t, strong_sum) + sig->strong_sum_len;
+    /* Round up to next multiple of sizeof(weak_sum) to align memory correctly. */
+    return offsetof(rs_block_sig_t, strong_sum) + ((sig->strong_sum_len + sizeof(rs_weak_sum_t) - 1) /
+	sizeof(rs_weak_sum_t)) * sizeof(rs_weak_sum_t);
 }
 
 /* Get the pointer to the block_sig_t from a block index. */


### PR DESCRIPTION
Fix rs_block_sig_size() for correct memory alignment when packing rs_block_sum_t instances in rs_signature_t instances.

Update NEWS.md with all changes since release of v2.0.1.