### PR TITLE
Fix #134 hashtable_test.c name collision for key_t.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,9 @@ NOT RELEASED YET
  * Fix Unaligned memory access for rs_block_sig_init() (dbaarda,
    https://github.com/librsync/librsync/issues/135).
 
+ * Fix hashtable_test.c name collision for key_t in sys/types.h on some
+   platforms (dbaarda, https://github.com/librsync/librsync/issues/134)
+   
 ## librsync 2.0.1
 
 Released 2017-10-17

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,7 +14,7 @@ NOT RELEASED YET
 
  * Fix hashtable_test.c name collision for key_t in sys/types.h on some
    platforms (dbaarda, https://github.com/librsync/librsync/issues/134)
-   
+
 ## librsync 2.0.1
 
 Released 2017-10-17

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -57,69 +57,70 @@
  * \param NAME - optional hashtable type basename (default: ENTRY_hashtable).
  *
  * Example: \code
- *   typedef ... key_t;
- *   int key_hash(const key_t *e);
- *   int key_cmp(key_t *e, const key_t *o);
+ *   typedef ... mykey_t;
+ *   int mykey_hash(const mykey_t *e);
+ *   int mykey_cmp(mykey_t *e, const mykey_t *o);
  *
- *   typedef struct entry {
- *     key_t key;  // Inherit from key_t.
+ *   typedef struct myentry {
+ *     mykey_t key;  // Inherit from mykey_t.
  *     ...extra entry value data...
- *   } entry_t;
- *   void entry_init(entry_t *e, ...);
+ *   } myentry_t;
+ *   void myentry_init(myentry_t *e, ...);
  *
- *   #define ENTRY entry
- *   #define KEY key
+ *   #define ENTRY myentry
+ *   #define KEY mykey
  *   #include "hashtable.h"
  *
  *   hashtable_t *t;
- *   entry_t entries[300];
- *   key_t k;
- *   entry_t *e;
+ *   myentry_t entries[300];
+ *   mykey_t k;
+ *   myentry_t *e;
  *
- *   t = entry_hashtable_new(300);
- *   entry_init(&entries[5], ...);
- *   entry_hashtable_add(t, &entries[5]);
+ *   t = myentry_hashtable_new(300);
+ *   myentry_init(&entries[5], ...);
+ *   myentry_hashtable_add(t, &entries[5]);
  *   k = ...;
- *   e = entry_hashtable_find(t, &k);
+ *   e = myentry_hashtable_find(t, &k);
  *
- *   hashtable_iter i;
- *   for (e = entry_hashtable_iter(&i, t); e != NULL; e = entry_hashtable_next(&i))
+ *   hashtable_iter_t i;
+ *   for (e = myentry_hashtable_iter(&i, t); e != NULL;
+ *        e = myentry_hashtable_next(&i))
  *     ...
  *
- *   entry_hashtable_free(t);
+ *   myentry_hashtable_free(t);
  * \endcode
  *
- * The key_hash() and key_cmp() fuctions will typically take pointers
- * to key/entry instances the same as the pointers stored in the
+ * The mykey_hash() and mykey_cmp() fuctions will typically take pointers
+ * to mykey/myentry instances the same as the pointers stored in the
  * hashtable. However it is also possible for them to take "match
  * objects" that are a "subclass" of the entry type that contain
  * additional state for complicated comparision operations.
  *
  * Example: \code
- *   typedef struct match {
- *     key_t key;  // Inherit from key_t;
+ *   typedef struct mymatch {
+ *     mykey_t key;  // Inherit from mykey_t;
  *     ...extra match criteria and state data...
- *   } match_t;
- *   int match_cmp(match_t *m, const entry_t *e);
+ *   } mymatch_t;
+ *   int mymatch_cmp(mymatch_t *m, const myentry_t *e);
  *
- *   #define ENTRY entry
- *   #define KEY key
- *   #define MATCH match
+ *   #define ENTRY myentry
+ *   #define KEY mykey
+ *   #define MATCH mymatch
  *   #include "hashtable.h"
  *
  *   ...
- *   match_t m;
+ *   mymatch_t m;
  *
- *   t = entry_hashtable_new(300);
+ *   t = myentry_hashtable_new(300);
  *   ...
  *   m = ...;
- *   e = entry_hashtable_find(t, &m);
+ *   e = myentry_hashtable_find(t, &m);
  * \endcode
  *
- * The match_cmp() function is only called for finding hashtable
- * entries and can mutate the match_t object for doing things like
+ * The mymatch_cmp() function is only called for finding hashtable
+ * entries and can mutate the mymatch_t object for doing things like
  * deferred and cached evaluation of expensive match data. It can
- * also access the whole entry_t object to match against more than
+ * also access the whole myentry_t object to match against more than
  * just the key. */
 
 /** The hashtable type. */

--- a/tests/hashtable_test.c
+++ b/tests/hashtable_test.c
@@ -27,32 +27,32 @@
 #include "hashtable.h"
 
 /* Key type for the hashtable. */
-typedef int key_t;
-void key_init(key_t *k, int i)
+typedef int mykey_t;
+void mykey_init(mykey_t *k, int i)
 {
     /* This is chosen to cause bad key collisions and clustering. */
     *k = (i / 2) * (i / 2);
 }
 
-int key_hash(const key_t *k)
+int mykey_hash(const mykey_t *k)
 {
     return *k;
 }
 
-int key_cmp(key_t *k, const key_t *o)
+int mykey_cmp(mykey_t *k, const mykey_t *o)
 {
     return *k - *o;
 }
 
 /* Entry type for values in hashtable. */
-typedef struct entry {
-    key_t key;                  /* Inherit from key_t. */
+typedef struct myentry {
+    mykey_t key;                  /* Inherit from mykey_t. */
     int value;
-} entry_t;
+} myentry_t;
 
-void entry_init(entry_t *e, int i)
+void myentry_init(myentry_t *e, int i)
 {
-    key_init(&e->key, i);
+    mykey_init(&e->key, i);
     e->value = i;
 }
 
@@ -60,22 +60,22 @@ void entry_init(entry_t *e, int i)
  *
  * This demonstrates using deferred calculation and comparison of the
  * expected value only when the key matches. */
-typedef struct match {
-    key_t key;                  /* Inherit from key_t. */
+typedef struct mymatch {
+    mykey_t key;                  /* Inherit from mykey_t. */
     int value;
     int source;
-} match_t;
+} mymatch_t;
 
-void match_init(match_t *m, int i)
+void mymatch_init(mymatch_t *m, int i)
 {
-    key_init(&m->key, i);
+    mykey_init(&m->key, i);
     m->value = 0;
     m->source = i;
 }
 
-int match_cmp(match_t *m, const entry_t *e)
+int mymatch_cmp(mymatch_t *m, const myentry_t *e)
 {
-    int ans = key_cmp(&m->key, &e->key);
+    int ans = mykey_cmp(&m->key, &e->key);
     /* Calculate and compare value if key matches */
     if (ans == 0) {
         if (m->value != m->source)
@@ -86,77 +86,77 @@ int match_cmp(match_t *m, const entry_t *e)
 }
 
 
-/* Instantiate a simple key_hashtable of keys. */
-#define ENTRY key
+/* Instantiate a simple mykey_hashtable of keys. */
+#define ENTRY mykey
 #include "hashtable.h"
 
-/* Instantiate a fancy hashtable of entrys using a custom match. */
-#define ENTRY entry
-#define KEY key
-#define MATCH match
-#define NAME hashtable
+/* Instantiate a fancy myhashtable of myentrys using a custom match. */
+#define ENTRY myentry
+#define KEY mykey
+#define MATCH mymatch
+#define NAME myhashtable
 #include "hashtable.h"
 
 /* Test driver for hashtable. */
 int main(int argc, char **argv)
 {
-    /* Test key_hashtable instance. */
+    /* Test mykey_hashtable instance. */
     hashtable_t *kt;
     hashtable_iter_t ki;
-    key_t k1, k2;
+    mykey_t k1, k2;
 
-    key_init(&k1, 1);
-    key_init(&k2, 2);
-    assert((kt = key_hashtable_new(16)) != NULL);
-    assert(key_hashtable_add(kt, &k1) == &k1);
-    assert(key_hashtable_find(kt, &k1) == &k1);
-    assert(key_hashtable_find(kt, &k2) == NULL);
-    assert(key_hashtable_iter(&ki, kt) == &k1);
-    assert(key_hashtable_next(&ki) == NULL);
+    mykey_init(&k1, 1);
+    mykey_init(&k2, 2);
+    assert((kt = mykey_hashtable_new(16)) != NULL);
+    assert(mykey_hashtable_add(kt, &k1) == &k1);
+    assert(mykey_hashtable_find(kt, &k1) == &k1);
+    assert(mykey_hashtable_find(kt, &k2) == NULL);
+    assert(mykey_hashtable_iter(&ki, kt) == &k1);
+    assert(mykey_hashtable_next(&ki) == NULL);
 
-    /* Test hashtable instance. */
+    /* Test myhashtable instance. */
     hashtable_t *t;
-    entry_t entry[256];
-    entry_t e;
-    match_t m;
+    myentry_t entry[256];
+    myentry_t e;
+    mymatch_t m;
     int i;
 
-    entry_init(&e, 0);
+    myentry_init(&e, 0);
     for (i = 0; i < 256; i++)
-        entry_init(&entry[i], i);
+        myentry_init(&entry[i], i);
 
-    /* Test hashtable_new() */
-    t = hashtable_new(256);
+    /* Test myhashtable_new() */
+    t = myhashtable_new(256);
     assert(t->size == 512);
     assert(t->count == 0);
     assert(t->etable != NULL);
     assert(t->ktable != NULL);
 
-    /* Test hashtable_add() */
-    assert(hashtable_add(t, &e) == &e); /* Added duplicated copy. */
-    assert(hashtable_add(t, &entry[0]) == &entry[0]);   /* Added duplicated instance. */
+    /* Test myhashtable_add() */
+    assert(myhashtable_add(t, &e) == &e); /* Added duplicated copy. */
+    assert(myhashtable_add(t, &entry[0]) == &entry[0]);   /* Added duplicated instance. */
     for (i = 0; i < 256; i++)
-        assert(hashtable_add(t, &entry[i]) == &entry[i]);
+        assert(myhashtable_add(t, &entry[i]) == &entry[i]);
     assert(t->count == 258);
 
-    /* Test hashtable_find() */
-    match_init(&m, 0);
-    assert(hashtable_find(t, &m) == &e);        /* Finds first duplicate added. */
-    assert(m.value == m.source);        /* match_cmp() updated m.value. */
+    /* Test myhashtable_find() */
+    mymatch_init(&m, 0);
+    assert(myhashtable_find(t, &m) == &e);        /* Finds first duplicate added. */
+    assert(m.value == m.source);        /* mymatch_cmp() updated m.value. */
     for (i = 1; i < 256; i++) {
-        match_init(&m, i);
-        assert(hashtable_find(t, &m) == &entry[i]);
-        assert(m.value == m.source);    /* match_cmp() updated m.value. */
+        mymatch_init(&m, i);
+        assert(myhashtable_find(t, &m) == &entry[i]);
+        assert(m.value == m.source);    /* mymatch_cmp() updated m.value. */
     }
-    match_init(&m, 256);
-    assert(hashtable_find(t, &m) == NULL);      /* Find missing entry. */
-    assert(m.value == 0);       /* match_cmp() didn't update m.value. */
+    mymatch_init(&m, 256);
+    assert(myhashtable_find(t, &m) == NULL);      /* Find missing myentry. */
+    assert(m.value == 0);       /* mymatch_cmp() didn't update m.value. */
 #ifndef HASHTABLE_NSTATS
     assert(t->find_count == 257);
     assert(t->match_count == 256);
     assert(t->hashcmp_count >= 256);
     assert(t->entrycmp_count >= 256);
-    hashtable_stats_init(t);
+    myhashtable_stats_init(t);
     assert(t->find_count == 0);
     assert(t->match_count == 0);
     assert(t->hashcmp_count == 0);
@@ -164,15 +164,15 @@ int main(int argc, char **argv)
 #endif
 
     /* Test hashtable iterators */
-    entry_t *p;
+    myentry_t *p;
     hashtable_iter_t iter;
     int count = 0;
-    for (p = hashtable_iter(&iter, t); p != NULL; p = hashtable_next(&iter)) {
+    for (p = myhashtable_iter(&iter, t); p != NULL; p = myhashtable_next(&iter)) {
         assert(p == &e || (&entry[0] <= p && p <= &entry[255]));
         count++;
     }
     assert(count == 258);
-    hashtable_free(t);
+    myhashtable_free(t);
 
     return 0;
 }


### PR DESCRIPTION
Rename key/entry/match/hashtable to mykey/myentry/mymatch/myhashtable in test and header docstrings. This reduces the chance of a collision and makes it clearer these names are arbitrary.