### PR TITLE
Fix 'make tidy' and 'make tidyc' to be consistent.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,11 +230,11 @@ add_custom_target(tidy
     #
     # Hide the enclosing 'extern "C" {...}' block for indenting in librsync.h
     COMMAND sed -r -i "s:^(extern \"C\") \\{:\\1;:; s:^\\}(\\s+/\\* extern \"C\" \\*/):;\\1:" src/librsync.h
-    # Linux format with no tabs, indent 4, preproc indent 2, 80 columns, format comments, swallow blank lines.
-    COMMAND indent -linux -nut -i4 -ppi2 -l80 -lc80 -fc1 -fca -sob -T FILE -T Rollsum -T rs_result ${tidy_SRCS}
+    # Linux format with no tabs, indent 4, preproc indent 2, 80 columns, swallow blank lines.
+    COMMAND indent -linux -nut -i4 -ppi2 -l80 -lc80 -fc1 -sob -T FILE -T Rollsum -T rs_result ${tidy_SRCS}
     # Remove space between * or & and identifier after userdefined types,
     # remove space after type cast for userdefined types like indent -ncs,
-    #and remove trailing whitespace.
+    # and remove trailing whitespace.
     COMMAND sed -r -i "s:((${TYPE_RE}|${CAST_RE}) (&|\\*+)) :\\1:g; s:(${CAST_RE}) :\\1:g; s:\\s+$::" ${tidy_SRCS}
     # Restore the enclosing 'extern "C" {...}' block in librsync.h
     COMMAND sed -r -i "s:^(extern \"C\");:\\1 {:; s:^;(\\s+/\\* extern \"C\" \\*/):}\\1:" src/librsync.h

--- a/src/buf.c
+++ b/src/buf.c
@@ -27,11 +27,11 @@
  * streams.
  *
  * As the stream consumes input and produces output, it is refilled from
- * appropriate input and output FILEs.  A dynamically allocated buffer of
+ * appropriate input and output FILEs. A dynamically allocated buffer of
  * configurable size is used as an intermediary.
  *
  * \todo Perhaps be more efficient by filling the buffer on every call even if
- * not yet completely empty.  Check that it's really our buffer, and shuffle
+ * not yet completely empty. Check that it's really our buffer, and shuffle
  * remaining data down to the front.
  *
  * \todo Perhaps expose a routine for shuffling the buffers. */
@@ -76,7 +76,7 @@ void rs_filebuf_free(rs_filebuf_t *fb)
 }
 
 /* If the stream has no more data available, read some from F into BUF, and let
-   the stream use that.  On return, SEEN_EOF is true if the end of file has
+   the stream use that. On return, SEEN_EOF is true if the end of file has
    passed into the stream. */
 rs_result rs_infilebuf_fill(rs_job_t *job, rs_buffers_t *buf, void *opaque)
 {
@@ -101,7 +101,7 @@ rs_result rs_infilebuf_fill(rs_job_t *job, rs_buffers_t *buf, void *opaque)
     }
 
     if (buf->avail_in)
-        /* Still some data remaining.  Perhaps we should read anyhow? */
+        /* Still some data remaining. Perhaps we should read anyhow? */
         return RS_DONE;
 
     len = fread(fb->buf, 1, fb->buf_len, f);
@@ -130,8 +130,7 @@ rs_result rs_infilebuf_fill(rs_job_t *job, rs_buffers_t *buf, void *opaque)
 }
 
 /* The buf is already using BUF for an output buffer, and probably contains
-   some buffered output now.  Write this out to F, and reset the buffer cursor.
- */
+   some buffered output now. Write this out to F, and reset the buffer cursor. */
 rs_result rs_outfilebuf_drain(rs_job_t *job, rs_buffers_t *buf, void *opaque)
 {
     int present;

--- a/src/checksum.c
+++ b/src/checksum.c
@@ -45,11 +45,11 @@ rs_weak_sum_t rs_calc_weak_sum(void const *buf, size_t len)
 /** Calculate and store into SUM a strong MD4 checksum of the file blocks seen
  * so far.
  *
- * In plain rsync, the checksum is perturbed by a seed value.  This is used
- * when retrying a failed transmission: we've discovered that the hashes
- * collided at some point, so we're going to try again with different hashes to
- * see if we can get it right.  (Check tridge's thesis for details and to see
- * if that's correct.)
+ * In plain rsync, the checksum is perturbed by a seed value.  This is used when
+ * retrying a failed transmission: we've discovered that the hashes collided at
+ * some point, so we're going to try again with different hashes to see if we can
+ * get it right.  (Check tridge's thesis for details and to see if that's
+ * correct.)
  *
  * Since we can't retry a web transaction I'm not sure if it's very useful in
  * rproxy. */

--- a/src/checksum.c
+++ b/src/checksum.c
@@ -45,10 +45,10 @@ rs_weak_sum_t rs_calc_weak_sum(void const *buf, size_t len)
 /** Calculate and store into SUM a strong MD4 checksum of the file blocks seen
  * so far.
  *
- * In plain rsync, the checksum is perturbed by a seed value.  This is used when
+ * In plain rsync, the checksum is perturbed by a seed value. This is used when
  * retrying a failed transmission: we've discovered that the hashes collided at
- * some point, so we're going to try again with different hashes to see if we can
- * get it right.  (Check tridge's thesis for details and to see if that's
+ * some point, so we're going to try again with different hashes to see if we
+ * can get it right. (Check tridge's thesis for details and to see if that's
  * correct.)
  *
  * Since we can't retry a web transaction I'm not sure if it's very useful in

--- a/src/command.h
+++ b/src/command.h
@@ -25,7 +25,7 @@
  * The vague idea is that eventually this file will be more abstract than
  * protocol.h, but it's not clear that will ever be required. */
 
-/** Classes of operation that can be present.  Each may have several different
+/** Classes of operation that can be present. Each may have several different
  * possible representations. */
 enum rs_op_kind {
     RS_KIND_END = 1000,
@@ -35,8 +35,8 @@ enum rs_op_kind {
     RS_KIND_CHECKSUM,
     RS_KIND_RESERVED,           /* for future expansion */
 
-    /* This one should never occur in file streams.  It's an internal marker
-       for invalid commands. */
+    /* This one should never occur in file streams. It's an internal marker for
+       invalid commands. */
     RS_KIND_INVALID
 };
 

--- a/src/delta.c
+++ b/src/delta.c
@@ -43,9 +43,9 @@
  * it may be a short match.  Short blocks in the signature don't include their
  * length -- we just allow for the final short block of the file to match any
  * block in the signature, and if they have the same checksum we assume they
- * must have the same length. Therefore, when we emit a COPY command, we have
- * to send it with a length that is the same as the block matched, and not the
- * block length from the signature.
+ * must have the same length. Therefore, when we emit a COPY command, we have to
+ * send it with a length that is the same as the block matched, and not the block
+ * length from the signature.
  *
  * Profiling results as of v1.26, 2001-03-18:
  *
@@ -56,36 +56,32 @@
  *
  * 2002-06-26: Donovan Baarda
  *
- * The following is based entirely on pysync. It is much cleaner than the
- * previous incarnation of this code. It is slightly complicated because in
- * this case the output can block, so the main delta loop needs to stop when
- * this happens.
+ * The following is based entirely on pysync. It is much cleaner than the previous
+ * incarnation of this code. It is slightly complicated because in this case the
+ * output can block, so the main delta loop needs to stop when this happens.
  *
  * In pysync a 'last' attribute is used to hold the last miss or match for
- * extending if possible. In this code, basis_len and scoop_pos are used
- * instead of 'last'. When basis_len > 0, last is a match. When basis_len = 0
- * and scoop_pos is > 0, last is a miss. When both are 0, last is None (ie,
- * nothing).
+ * extending if possible. In this code, basis_len and scoop_pos are used instead of
+ * 'last'. When basis_len > 0, last is a match. When basis_len = 0 and scoop_pos is
+ * > 0, last is a miss. When both are 0, last is None (ie, nothing).
  *
- * Pysync is also slightly different in that a 'flush' method is available to
- * force output of accumulated data. This 'flush' is use to finalise delta
- * calculation. In librsync input is terminated with an eof flag on the input
- * stream. I have structured this code similar to pysync with a seperate flush
- * function that is used when eof is reached. This allows for a flush style API
- * if one is ever needed. Note that flush in pysync can be used for more than
- * just terminating delta calculation, so a flush based API can in some ways be
- * more flexible...
+ * Pysync is also slightly different in that a 'flush' method is available to force
+ * output of accumulated data. This 'flush' is use to finalise delta calculation. In
+ * librsync input is terminated with an eof flag on the input stream. I have
+ * structured this code similar to pysync with a seperate flush function that is used
+ * when eof is reached. This allows for a flush style API if one is ever needed. Note
+ * that flush in pysync can be used for more than just terminating delta calculation,
+ * so a flush based API can in some ways be more flexible...
  *
- * The input data is first scanned, then processed. Scanning identifies input
- * data as misses or matches, and emits the instruction stream. Processing the
- * data consumes it off the input scoop and outputs the processed miss data
- * into the tube.
+ * The input data is first scanned, then processed. Scanning identifies input data as
+ * misses or matches, and emits the instruction stream. Processing the data consumes
+ * it off the input scoop and outputs the processed miss data into the tube.
  *
- * The scoop contains all data yet to be processed. The scoop_pos is an index
- * into the scoop that indicates the point scanned to. As data is scanned,
- * scoop_pos is incremented. As data is processed, it is removed from the scoop
- * and scoop_pos adjusted. Everything gets complicated because the tube can
- * block. When the tube is blocked, no data can be processed. */
+ * The scoop contains all data yet to be processed. The scoop_pos is an index into the
+ * scoop that indicates the point scanned to. As data is scanned, scoop_pos is
+ * incremented. As data is processed, it is removed from the scoop and scoop_pos
+ * adjusted. Everything gets complicated because the tube can block. When the tube is
+ * blocked, no data can be processed. */
 
 #include "config.h"
 

--- a/src/delta.c
+++ b/src/delta.c
@@ -33,19 +33,19 @@
  * in the incoming signature.
  *
  * To calculate a signature, we need to be able to see at least one block of
- * the new file at a time.  Once we have that, we calculate its weak signature,
+ * the new file at a time. Once we have that, we calculate its weak signature,
  * and see if there is any block in the signature hash table that has the same
- * weak sum.  If there is one, then we also compute the strong sum of the new
+ * weak sum. If there is one, then we also compute the strong sum of the new
  * block, and cross check that. If they're the same, then we can assume we have
  * a match.
  *
  * The final block of the file has to be handled a little differently, because
- * it may be a short match.  Short blocks in the signature don't include their
+ * it may be a short match. Short blocks in the signature don't include their
  * length -- we just allow for the final short block of the file to match any
  * block in the signature, and if they have the same checksum we assume they
- * must have the same length. Therefore, when we emit a COPY command, we have to
- * send it with a length that is the same as the block matched, and not the block
- * length from the signature.
+ * must have the same length. Therefore, when we emit a COPY command, we have
+ * to send it with a length that is the same as the block matched, and not the
+ * block length from the signature.
  *
  * Profiling results as of v1.26, 2001-03-18:
  *
@@ -56,32 +56,36 @@
  *
  * 2002-06-26: Donovan Baarda
  *
- * The following is based entirely on pysync. It is much cleaner than the previous
- * incarnation of this code. It is slightly complicated because in this case the
- * output can block, so the main delta loop needs to stop when this happens.
+ * The following is based entirely on pysync. It is much cleaner than the
+ * previous incarnation of this code. It is slightly complicated because in
+ * this case the output can block, so the main delta loop needs to stop when
+ * this happens.
  *
  * In pysync a 'last' attribute is used to hold the last miss or match for
- * extending if possible. In this code, basis_len and scoop_pos are used instead of
- * 'last'. When basis_len > 0, last is a match. When basis_len = 0 and scoop_pos is
- * > 0, last is a miss. When both are 0, last is None (ie, nothing).
+ * extending if possible. In this code, basis_len and scoop_pos are used
+ * instead of 'last'. When basis_len > 0, last is a match. When basis_len = 0
+ * and scoop_pos is > 0, last is a miss. When both are 0, last is None (ie,
+ * nothing).
  *
- * Pysync is also slightly different in that a 'flush' method is available to force
- * output of accumulated data. This 'flush' is use to finalise delta calculation. In
- * librsync input is terminated with an eof flag on the input stream. I have
- * structured this code similar to pysync with a seperate flush function that is used
- * when eof is reached. This allows for a flush style API if one is ever needed. Note
- * that flush in pysync can be used for more than just terminating delta calculation,
- * so a flush based API can in some ways be more flexible...
+ * Pysync is also slightly different in that a 'flush' method is available to
+ * force output of accumulated data. This 'flush' is use to finalise delta
+ * calculation. In librsync input is terminated with an eof flag on the input
+ * stream. I have structured this code similar to pysync with a seperate flush
+ * function that is used when eof is reached. This allows for a flush style API
+ * if one is ever needed. Note that flush in pysync can be used for more than
+ * just terminating delta calculation, so a flush based API can in some ways be
+ * more flexible...
  *
- * The input data is first scanned, then processed. Scanning identifies input data as
- * misses or matches, and emits the instruction stream. Processing the data consumes
- * it off the input scoop and outputs the processed miss data into the tube.
+ * The input data is first scanned, then processed. Scanning identifies input
+ * data as misses or matches, and emits the instruction stream. Processing the
+ * data consumes it off the input scoop and outputs the processed miss data
+ * into the tube.
  *
- * The scoop contains all data yet to be processed. The scoop_pos is an index into the
- * scoop that indicates the point scanned to. As data is scanned, scoop_pos is
- * incremented. As data is processed, it is removed from the scoop and scoop_pos
- * adjusted. Everything gets complicated because the tube can block. When the tube is
- * blocked, no data can be processed. */
+ * The scoop contains all data yet to be processed. The scoop_pos is an index
+ * into the scoop that indicates the point scanned to. As data is scanned,
+ * scoop_pos is incremented. As data is processed, it is removed from the scoop
+ * and scoop_pos adjusted. Everything gets complicated because the tube can
+ * block. When the tube is blocked, no data can be processed. */
 
 #include "config.h"
 

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -38,15 +38,14 @@
  * Multiple entries with the same key can be added, and you can use a fancy
  * cmp() function to find particular entries by more than just their key. There
  * is an iterator for iterating through all entries in the hashtable. There are
- * optional hashtable_find() find/match/hashcmp/entrycmp stats counters that
- * can be disabled by defining HASHTABLE_NSTATS.
+ * optional hashtable_find() find/match/hashcmp/entrycmp stats counters that can
+ * be disabled by defining HASHTABLE_NSTATS.
  *
- * The types and methods of the hashtable and its contents are specified by
- * using \#define parameters set to their basenames (the prefixes for the *_t
- * type and *_func() methods) before doing \#include "hashtable.h". This
- * produces static inline type-safe methods that are either application
- * optimized for speed or wrappers around void* implementation methods for
- * compactness.
+ * The types and methods of the hashtable and its contents are specified by using
+ * \#define parameters set to their basenames (the prefixes for the *_t type and
+ * *_func() methods) before doing \#include "hashtable.h". This produces static
+ * inline type-safe methods that are either application optimized for speed or
+ * wrappers around void* implementation methods for compactness.
  *
  * \param ENTRY - the entry type basename.
  *

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -38,14 +38,15 @@
  * Multiple entries with the same key can be added, and you can use a fancy
  * cmp() function to find particular entries by more than just their key. There
  * is an iterator for iterating through all entries in the hashtable. There are
- * optional hashtable_find() find/match/hashcmp/entrycmp stats counters that can
- * be disabled by defining HASHTABLE_NSTATS.
+ * optional hashtable_find() find/match/hashcmp/entrycmp stats counters that
+ * can be disabled by defining HASHTABLE_NSTATS.
  *
- * The types and methods of the hashtable and its contents are specified by using
- * \#define parameters set to their basenames (the prefixes for the *_t type and
- * *_func() methods) before doing \#include "hashtable.h". This produces static
- * inline type-safe methods that are either application optimized for speed or
- * wrappers around void* implementation methods for compactness.
+ * The types and methods of the hashtable and its contents are specified by
+ * using \#define parameters set to their basenames (the prefixes for the *_t
+ * type and *_func() methods) before doing \#include "hashtable.h". This
+ * produces static inline type-safe methods that are either application
+ * optimized for speed or wrappers around void* implementation methods for
+ * compactness.
  *
  * \param ENTRY - the entry type basename.
  *

--- a/src/job.h
+++ b/src/job.h
@@ -34,7 +34,7 @@ struct rs_job {
     /** Callback for each processing step. */
     rs_result (*statefn) (rs_job_t *);
 
-    /** Final result of processing job.  Used by rs_job_s_failed(). */
+    /** Final result of processing job. Used by rs_job_s_failed(). */
     rs_result final_result;
 
     /* Arguments for initializing the signature used by mksum.c and readsums.c.
@@ -71,7 +71,7 @@ struct rs_job {
     /** Encoding statistics. */
     rs_stats_t stats;
 
-    /** Buffer of data in the scoop.  Allocation is scoop_buf[0..scoop_alloc],
+    /** Buffer of data in the scoop. Allocation is scoop_buf[0..scoop_alloc],
      * and scoop_next[0..scoop_avail] contains data yet to be processed.
      * scoop_next[scoop_pos..scoop_avail] is the data yet to be scanned. */
     rs_byte_t *scoop_buf;       /* the allocation pointer */

--- a/src/librsync.h
+++ b/src/librsync.h
@@ -292,9 +292,9 @@ void rs_sumset_dump(rs_signature_t const *);
  *
  * Note also that if *#avail_in is nonzero on return, then not all of the input
  * data has been consumed.  The caller should either provide more output buffer
- * space and call ::rs_job_iter() again passing the same #next_in and
- * #avail_in, or put the remaining input data into some persistent buffer and
- * call rs_job_iter() with it again when there is more output space.
+ * space and call ::rs_job_iter() again passing the same #next_in and #avail_in,
+ * or put the remaining input data into some persistent buffer and call
+ * rs_job_iter() with it again when there is more output space.
  *
  * \sa rs_job_iter() */
 struct rs_buffers_s {
@@ -308,8 +308,8 @@ struct rs_buffers_s {
     /** Number of bytes available at next_in.
      *
      * References the length of available input.  Updated to be the number of
-     * unused data bytes, which will be zero if all the input was consumed.
-     * May be zero if there is no new input, but the caller just wants to drain
+     * unused data bytes, which will be zero if all the input was consumed. May
+     * be zero if there is no new input, but the caller just wants to drain
      * output. */
     size_t avail_in;
 
@@ -422,8 +422,8 @@ rs_result rs_build_hash_table(rs_signature_t *sums);
  * \param pos Position where copying should begin.
  *
  * \param len On input, the amount of data that should be retrieved. Updated to
- * show how much is actually available, but should not be greater than the
- * input value.
+ * show how much is actually available, but should not be greater than the input
+ * value.
  *
  * \param buf On input, a buffer of at least \p *len bytes.  May be updated to
  * point to a buffer allocated by the callback if it prefers. */
@@ -440,9 +440,8 @@ typedef rs_result rs_copy_cb(void *opaque, rs_long_t pos, size_t *len,
  *
  * \param copy_arg Opaque environment pointer passed through to the callback.
  *
- * \todo As output is produced, accumulate the MD4 checksum of the output.
- * Then if we find a CHECKSUM command we can check it's contents against the
- * output.
+ * \todo As output is produced, accumulate the MD4 checksum of the output. Then
+ * if we find a CHECKSUM command we can check it's contents against the output.
  *
  * \todo Implement COPY commands.
  *

--- a/src/librsync.h
+++ b/src/librsync.h
@@ -240,7 +240,7 @@ void rs_mdfour_result(rs_mdfour_t *md, unsigned char *out);
 
 /** Return a human-readable representation of statistics.
  *
- * The string is truncated if it does not fit.  100 characters should be
+ * The string is truncated if it does not fit. 100 characters should be
  * sufficient space.
  *
  * \param stats Statistics from an encoding or decoding operation.
@@ -281,8 +281,8 @@ void rs_sumset_dump(rs_signature_t const *);
  * Buffers must be allocated and passed in by the caller.
  *
  * On input, the buffers structure must contain the address and length of the
- * input and output buffers.  The library updates these values to indicate the
- * amount of \b remaining buffer.  So, on return, #avail_out is not the amount
+ * input and output buffers. The library updates these values to indicate the
+ * amount of \b remaining buffer. So, on return, #avail_out is not the amount
  * of output data produced, but rather the amount of output buffer space still
  * available.
  *
@@ -291,23 +291,23 @@ void rs_sumset_dump(rs_signature_t const *);
  * directly tell you how much output data was produced.
  *
  * Note also that if *#avail_in is nonzero on return, then not all of the input
- * data has been consumed.  The caller should either provide more output buffer
- * space and call ::rs_job_iter() again passing the same #next_in and #avail_in,
- * or put the remaining input data into some persistent buffer and call
- * rs_job_iter() with it again when there is more output space.
+ * data has been consumed. The caller should either provide more output buffer
+ * space and call ::rs_job_iter() again passing the same #next_in and
+ * #avail_in, or put the remaining input data into some persistent buffer and
+ * call rs_job_iter() with it again when there is more output space.
  *
  * \sa rs_job_iter() */
 struct rs_buffers_s {
     /** Next input byte.
      *
      * References a pointer which on entry should point to the start of the
-     * data to be encoded.  Updated to point to the byte after the last one
+     * data to be encoded. Updated to point to the byte after the last one
      * consumed. */
     char *next_in;
 
     /** Number of bytes available at next_in.
      *
-     * References the length of available input.  Updated to be the number of
+     * References the length of available input. Updated to be the number of
      * unused data bytes, which will be zero if all the input was consumed. May
      * be zero if there is no new input, but the caller just wants to drain
      * output. */
@@ -319,7 +319,7 @@ struct rs_buffers_s {
     /** Next output byte should be put there.
      *
      * References a pointer which on entry points to the start of the output
-     * buffer.  Updated to point to the byte after the last one filled. */
+     * buffer. Updated to point to the byte after the last one filled. */
     char *next_out;
 
     /** Remaining free space at next_out.
@@ -356,7 +356,7 @@ typedef struct rs_job rs_job_t;
  * \return The ::rs_result that caused iteration to stop.
  *
  * \c buffers->eof_in should be true if there is no more data after what's in
- * the input buffer.  The final block checksum will run across whatever's in
+ * the input buffer. The final block checksum will run across whatever's in
  * there, without trying to accumulate anything else.
  *
  * \sa \ref api_streaming */
@@ -386,11 +386,11 @@ rs_result rs_job_free(rs_job_t *);
  * \param sig_magic Indicates the version of signature file format to generate.
  * See ::rs_magic_number.
  *
- * \param new_block_len Size of checksum blocks.  Larger values make the
+ * \param new_block_len Size of checksum blocks. Larger values make the
  * signature shorter, and the delta longer.
  *
  * \param strong_sum_len If non-zero, truncate the strong signatures to this
- * many bytes, to make the signature shorter.  It's recommended you leave this
+ * many bytes, to make the signature shorter. It's recommended you leave this
  * at zero to get the full strength.
  *
  * \sa rs_sig_file() */
@@ -422,10 +422,10 @@ rs_result rs_build_hash_table(rs_signature_t *sums);
  * \param pos Position where copying should begin.
  *
  * \param len On input, the amount of data that should be retrieved. Updated to
- * show how much is actually available, but should not be greater than the input
- * value.
+ * show how much is actually available, but should not be greater than the
+ * input value.
  *
- * \param buf On input, a buffer of at least \p *len bytes.  May be updated to
+ * \param buf On input, a buffer of at least \p *len bytes. May be updated to
  * point to a buffer allocated by the callback if it prefers. */
 typedef rs_result rs_copy_cb(void *opaque, rs_long_t pos, size_t *len,
                              void **buf);
@@ -433,7 +433,7 @@ typedef rs_result rs_copy_cb(void *opaque, rs_long_t pos, size_t *len,
 /** Apply a \a delta to a \a basis file to recreate the \a new file.
  *
  * This gives you back a ::rs_job_t object, which can be cranked by calling
- * rs_job_iter() and updating the stream pointers.  When finished, call
+ * rs_job_iter() and updating the stream pointers. When finished, call
  * rs_job_free() to dispose of it.
  *
  * \param copy_cb Callback used to retrieve content from the basis file.

--- a/src/mdfour.c
+++ b/src/mdfour.c
@@ -72,8 +72,8 @@ static void rs_mdfour_block(rs_mdfour_t *md, void const *p);
  * contain the file length.  rs_mdfour_tail() is used for that.
  *
  * \todo Recode to be fast, and to use system integer types.  Perhaps if we can
- * find an mdfour implementation already on the system (e.g. in OpenSSL) then
- * we should use it instead of our own?
+ * find an mdfour implementation already on the system (e.g. in OpenSSL) then we
+ * should use it instead of our own?
  *
  * \param X A series of integer, read little-endian from the file. */
 static void rs_mdfour64(rs_mdfour_t *m, const void *p)

--- a/src/mdfour.c
+++ b/src/mdfour.c
@@ -69,11 +69,11 @@ static void rs_mdfour_block(rs_mdfour_t *md, void const *p);
 /** Update an MD4 accumulator from a 64-byte chunk.
  *
  * This cannot be used for the last chunk of the file, which must be padded and
- * contain the file length.  rs_mdfour_tail() is used for that.
+ * contain the file length. rs_mdfour_tail() is used for that.
  *
- * \todo Recode to be fast, and to use system integer types.  Perhaps if we can
- * find an mdfour implementation already on the system (e.g. in OpenSSL) then we
- * should use it instead of our own?
+ * \todo Recode to be fast, and to use system integer types. Perhaps if we can
+ * find an mdfour implementation already on the system (e.g. in OpenSSL) then
+ * we should use it instead of our own?
  *
  * \param X A series of integer, read little-endian from the file. */
 static void rs_mdfour64(rs_mdfour_t *m, const void *p)
@@ -154,8 +154,8 @@ static void rs_mdfour64(rs_mdfour_t *m, const void *p)
 }
 
 /** These next routines are necessary because MD4 is specified in terms of
- * little-endian int32s, but we have a byte buffer.  On little-endian
- * platforms, I think we can just use the buffer pointer directly.
+ * little-endian int32s, but we have a byte buffer. On little-endian platforms,
+ * I think we can just use the buffer pointer directly.
  *
  * There are some nice endianness routines in glib, including assembler
  * variants. If we ever depended on glib, then it could be good to use them

--- a/src/mksum.c
+++ b/src/mksum.c
@@ -23,11 +23,11 @@
 /** \file mksum.c Generate file signatures.
  *
  * Generating checksums is pretty easy, since we can always just process
- * whatever data is available.  When a whole block has arrived, or we've
- * reached the end of the file, we write the checksum out.
+ * whatever data is available. When a whole block has arrived, or we've reached
+ * the end of the file, we write the checksum out.
  *
  * \todo Perhaps force blocks to be a multiple of 64 bytes, so that we can be
- * sure checksum generation will be more efficient.  I guess it will be OK at
+ * sure checksum generation will be more efficient. I guess it will be OK at
  * the moment, though, because tails are only used if necessary. */
 
 #include "config.h"
@@ -69,7 +69,7 @@ static rs_result rs_sig_s_header(rs_job_t *job)
     return RS_RUNNING;
 }
 
-/** Generate the checksums for a block and write it out.  Called when we
+/** Generate the checksums for a block and write it out. Called when we
  * already know we have enough data in memory at \p block. \private */
 static rs_result rs_sig_do_block(rs_job_t *job, const void *block, size_t len)
 {

--- a/src/netint.c
+++ b/src/netint.c
@@ -29,7 +29,7 @@
 
 /** \file netint.c Network-byte-order output to the tube.
  *
- * All the `suck' routines return a result code.  The most common values are
+ * All the `suck' routines return a result code. The most common values are
  * RS_DONE if they have enough data, or RS_BLOCKED if there is not enough input
  * to proceed.
  *
@@ -39,7 +39,7 @@
  *
  * \todo If we don't have <stdint.h> (or perhaps even if we do), determine
  * endianness and integer size by hand and use that to do our own conversion
- * routines.  We possibly need this anyhow to do 64-bit integers, since there
+ * routines. We possibly need this anyhow to do 64-bit integers, since there
  * seems to be no ntohs() analog. */
 
 #include "config.h"

--- a/src/patch.c
+++ b/src/patch.c
@@ -47,8 +47,8 @@ static rs_result rs_patch_s_literal(rs_job_t *);
 static rs_result rs_patch_s_copy(rs_job_t *);
 static rs_result rs_patch_s_copying(rs_job_t *);
 
-/** State of trying to read the first byte of a command.  Once we've taken
- * that in, we can know how much data to read to get the arguments. */
+/** State of trying to read the first byte of a command. Once we've taken that
+ * in, we can know how much data to read to get the arguments. */
 static rs_result rs_patch_s_cmdbyte(rs_job_t *job)
 {
     rs_result result;

--- a/src/rdiff.c
+++ b/src/rdiff.c
@@ -28,16 +28,16 @@
 
 /** \file rdiff.c -- Command-line network-delta tool.
  *
- * \todo Add a -z option to gzip/gunzip patches.  This would be somewhat
- * useful, but more importantly a good test of the streaming API.  Also add -I
- * for bzip2.
+ * \todo Add a -z option to gzip/gunzip patches. This would be somewhat useful,
+ * but more importantly a good test of the streaming API. Also add -I for
+ * bzip2.
  *
  * \todo If built with debug support and we have mcheck, then turn it on.
  * (Optionally?)
  *
  * \todo popt doesn't handle single dashes very well at the moment: we'd like
  * to use them as arguments to indicate stdin/stdout, but it turns them into
- * options.  I sent a patch to the popt maintainers; hopefully it will be fixed
+ * options. I sent a patch to the popt maintainers; hopefully it will be fixed
  * in the future.
  *
  * \todo Add an option for delta to check whether the files are identical. */

--- a/src/scoop.c
+++ b/src/scoop.c
@@ -28,17 +28,17 @@
 /** \file scoop.c This file deals with readahead from caller-supplied buffers.
  *
  * Many functions require a certain minimum amount of input to do their
- * processing.  For example, to calculate a strong checksum of a block we need
+ * processing. For example, to calculate a strong checksum of a block we need
  * at least a block of input.
  *
  * Since we put the buffers completely under the control of the caller, we
- * can't count on ever getting this much data all in one go.  We can't simply
+ * can't count on ever getting this much data all in one go. We can't simply
  * wait, because the caller might have a smaller buffer than we require and so
- * we'll never get it.  For the same reason we must always accept all the data
+ * we'll never get it. For the same reason we must always accept all the data
  * we're given.
  *
  * So, stream input data that's required for readahead is put into a special
- * buffer, from which the caller can then read.  It's essentially like an
+ * buffer, from which the caller can then read. It's essentially like an
  * internal pipe, which on any given read request may or may not be able to
  * actually supply the data.
  *
@@ -46,11 +46,11 @@
  * buffer if there's already enough there.
  *
  * \todo We probably know a maximum amount of data that can be scooped up, so
- * we could just avoid dynamic allocation.  However that can't be fixed at
+ * we could just avoid dynamic allocation. However that can't be fixed at
  * compile time, because when generating a delta it needs to be large enough to
- * hold one full block.  Perhaps we can set it up when the job is allocated? It
- * would be kind of nice to not do any memory allocation after startup, as bzlib
- * does this. */
+ * hold one full block. Perhaps we can set it up when the job is allocated? It
+ * would be kind of nice to not do any memory allocation after startup, as
+ * bzlib does this. */
 
 #include "config.h"
 
@@ -113,7 +113,7 @@ void rs_scoop_input(rs_job_t *job, size_t len)
  * This is used after doing readahead, when you decide you want to keep it. \p
  * len must be no more than the amount of available data, so you can't cheat.
  *
- * So when creating a delta, we require one block of readahead.  But after
+ * So when creating a delta, we require one block of readahead. But after
  * examining that block, we might decide to advance over all of it (if there is
  * a match), or just one byte (if not). */
 void rs_scoop_advance(rs_job_t *job, size_t len)
@@ -139,13 +139,13 @@ void rs_scoop_advance(rs_job_t *job, size_t len)
 
 /** Read from scoop without advancing.
  *
- * Ask for LEN bytes of input from the stream.  If that much data is available,
- * then return a pointer to it in PTR, advance the stream input pointer over the
- * data, and return RS_DONE.  If there's not enough data, then accept whatever is
- * there into a buffer, advance over it, and return RS_BLOCKED.
+ * Ask for LEN bytes of input from the stream. If that much data is available,
+ * then return a pointer to it in PTR, advance the stream input pointer over
+ * the data, and return RS_DONE. If there's not enough data, then accept
+ * whatever is there into a buffer, advance over it, and return RS_BLOCKED.
  *
- * The data is not actually removed from the input, so this function lets you do
- * readahead.  If you want to keep any of the data, you should also call
+ * The data is not actually removed from the input, so this function lets you
+ * do readahead. If you want to keep any of the data, you should also call
  * rs_scoop_advance() to skip over it. */
 rs_result rs_scoop_readahead(rs_job_t *job, size_t len, void **ptr)
 {

--- a/src/scoop.c
+++ b/src/scoop.c
@@ -49,8 +49,8 @@
  * we could just avoid dynamic allocation.  However that can't be fixed at
  * compile time, because when generating a delta it needs to be large enough to
  * hold one full block.  Perhaps we can set it up when the job is allocated? It
- * would be kind of nice to not do any memory allocation after startup, as
- * bzlib does this. */
+ * would be kind of nice to not do any memory allocation after startup, as bzlib
+ * does this. */
 
 #include "config.h"
 
@@ -140,12 +140,12 @@ void rs_scoop_advance(rs_job_t *job, size_t len)
 /** Read from scoop without advancing.
  *
  * Ask for LEN bytes of input from the stream.  If that much data is available,
- * then return a pointer to it in PTR, advance the stream input pointer over
- * the data, and return RS_DONE.  If there's not enough data, then accept
- * whatever is there into a buffer, advance over it, and return RS_BLOCKED.
+ * then return a pointer to it in PTR, advance the stream input pointer over the
+ * data, and return RS_DONE.  If there's not enough data, then accept whatever is
+ * there into a buffer, advance over it, and return RS_BLOCKED.
  *
- * The data is not actually removed from the input, so this function lets you
- * do readahead.  If you want to keep any of the data, you should also call
+ * The data is not actually removed from the input, so this function lets you do
+ * readahead.  If you want to keep any of the data, you should also call
  * rs_scoop_advance() to skip over it. */
 rs_result rs_scoop_readahead(rs_job_t *job, size_t len, void **ptr)
 {

--- a/src/stream.c
+++ b/src/stream.c
@@ -32,17 +32,17 @@
  * See \sa scoop.c and \sa tube.c for related code for input and output
  * respectively.
  *
- * OK, so I'll admit IO here is a little complex.  The most important player
- * here is the stream, which is an object for managing filter operations.  It
+ * OK, so I'll admit IO here is a little complex. The most important player
+ * here is the stream, which is an object for managing filter operations. It
  * has both input and output sides, both of which is just a (pointer,len) pair
  * into a buffer provided by the client. The code controlling the stream
  * handles however much data it wants, and the client provides or accepts
  * however much is convenient.
  *
  * At the same time as being friendly to the client, we also try to be very
- * friendly to the internal code.  It wants to be able to ask for arbitrary
+ * friendly to the internal code. It wants to be able to ask for arbitrary
  * amounts of input or output and get it without having to keep track of
- * partial completion.  So there are functions which either complete, or queue
+ * partial completion. So there are functions which either complete, or queue
  * whatever was not sent and return RS_BLOCKED.
  *
  * The output buffer is a little more clever than simply a data buffer. Instead
@@ -54,27 +54,27 @@
  * So on return from an encoding function, either the input or the output or
  * possibly both will have no more bytes available.
  *
- * librsync never does IO or memory allocation, but relies on the caller.  This
- * is very nice for integration, but means that we have to be fairly flexible as
- * to when we can `read' or `write' stuff internally.
+ * librsync never does IO or memory allocation, but relies on the caller. This
+ * is very nice for integration, but means that we have to be fairly flexible
+ * as to when we can `read' or `write' stuff internally.
  *
- * librsync basically does two types of IO.  It reads network integers of various
- * lengths which encode command and control information such as versions and
- * signatures.  It also does bulk data transfer.
+ * librsync basically does two types of IO. It reads network integers of
+ * various lengths which encode command and control information such as
+ * versions and signatures. It also does bulk data transfer.
  *
  * IO of network integers is internally buffered, because higher levels of the
  * code need to see them transmitted atomically: it's no good to read half of a
- * uint32.  So there is a small and fixed length internal buffer which accumulates
- * these.  Unlike previous versions of the library, we don't require that the
- * caller hold the start until the whole thing has arrived, which guarantees that
- * we can always make progress.
+ * uint32. So there is a small and fixed length internal buffer which
+ * accumulates these. Unlike previous versions of the library, we don't require
+ * that the caller hold the start until the whole thing has arrived, which
+ * guarantees that we can always make progress.
  *
- * On each call into a stream iterator, it should begin by trying to flush output.
- * This may well use up all the remaining stream space, in which case nothing else
- * can be done.
+ * On each call into a stream iterator, it should begin by trying to flush
+ * output. This may well use up all the remaining stream space, in which case
+ * nothing else can be done.
  *
- * \todo Kill this file and move the vestigial code remaining closer to where it's
- * used. */
+ * \todo Kill this file and move the vestigial code remaining closer to where
+ * it's used. */
 
 #include "config.h"
 
@@ -93,7 +93,7 @@
  * \return the number of bytes actually copied, which may be less than LEN if
  * there is not enough space in one or the other stream.
  *
- * This always does the copy immediately.  Most functions should call
+ * This always does the copy immediately. Most functions should call
  * rs_tube_copy() to cause the copy to happen gradually as space becomes
  * available. */
 int rs_buffers_copy(rs_buffers_t *stream, int max_len)
@@ -132,7 +132,7 @@ int rs_buffers_copy(rs_buffers_t *stream, int max_len)
 /** Assert input is empty or output is full.
  *
  * Whenever a stream processing function exits, it should have done so because
- * it has either consumed all the input or has filled the output buffer.  This
+ * it has either consumed all the input or has filled the output buffer. This
  * function checks that simple postcondition. */
 void rs_buffers_check_exit(rs_buffers_t const *stream)
 {

--- a/src/stream.c
+++ b/src/stream.c
@@ -45,9 +45,9 @@
  * partial completion.  So there are functions which either complete, or queue
  * whatever was not sent and return RS_BLOCKED.
  *
- * The output buffer is a little more clever than simply a data buffer.
- * Instead it knows that we can send either literal data, or data copied
- * through from the input of the stream.
+ * The output buffer is a little more clever than simply a data buffer. Instead
+ * it knows that we can send either literal data, or data copied through from
+ * the input of the stream.
  *
  * In buf.c you will find functions that then map buffers onto stdio files.
  *
@@ -55,26 +55,26 @@
  * possibly both will have no more bytes available.
  *
  * librsync never does IO or memory allocation, but relies on the caller.  This
- * is very nice for integration, but means that we have to be fairly flexible
- * as to when we can `read' or `write' stuff internally.
+ * is very nice for integration, but means that we have to be fairly flexible as
+ * to when we can `read' or `write' stuff internally.
  *
- * librsync basically does two types of IO.  It reads network integers of
- * various lengths which encode command and control information such as
- * versions and signatures.  It also does bulk data transfer.
+ * librsync basically does two types of IO.  It reads network integers of various
+ * lengths which encode command and control information such as versions and
+ * signatures.  It also does bulk data transfer.
  *
  * IO of network integers is internally buffered, because higher levels of the
  * code need to see them transmitted atomically: it's no good to read half of a
- * uint32.  So there is a small and fixed length internal buffer which
- * accumulates these.  Unlike previous versions of the library, we don't
- * require that the caller hold the start until the whole thing has arrived,
- * which guarantees that we can always make progress.
+ * uint32.  So there is a small and fixed length internal buffer which accumulates
+ * these.  Unlike previous versions of the library, we don't require that the
+ * caller hold the start until the whole thing has arrived, which guarantees that
+ * we can always make progress.
  *
- * On each call into a stream iterator, it should begin by trying to flush
- * output.  This may well use up all the remaining stream space, in which case
- * nothing else can be done.
+ * On each call into a stream iterator, it should begin by trying to flush output.
+ * This may well use up all the remaining stream space, in which case nothing else
+ * can be done.
  *
- * \todo Kill this file and move the vestigial code remaining closer to where
- * it's used. */
+ * \todo Kill this file and move the vestigial code remaining closer to where it's
+ * used. */
 
 #include "config.h"
 

--- a/src/sumset.h
+++ b/src/sumset.h
@@ -27,7 +27,7 @@
 /** Signature of a single block. */
 typedef struct rs_block_sig {
     rs_weak_sum_t weak_sum;     /**< Block's weak checksum. */
-    rs_strong_sum_t strong_sum; /**< Block's strong checksum.  */
+    rs_strong_sum_t strong_sum; /**< Block's strong checksum. */
 } rs_block_sig_t;
 
 /** Signature of a whole file.

--- a/src/trace.c
+++ b/src/trace.c
@@ -63,7 +63,7 @@ int rs_trace_level = RS_LOG_INFO;
 
 static void rs_log_va(int level, char const *fn, char const *fmt, va_list va);
 
-/** Log severity strings, if any.  Must match ordering in ::rs_loglevel. */
+/** Log severity strings, if any. Must match ordering in ::rs_loglevel. */
 static const char *rs_severities[] = {
     "EMERGENCY! ", "ALERT! ", "CRITICAL! ", "ERROR: ", "Warning: ",
     "", "", ""

--- a/src/trace.h
+++ b/src/trace.h
@@ -27,8 +27,8 @@
  *
  * fatal terminates the whole process.
  *
- * \todo A function like perror that includes strerror output.  Apache does
- * this by adding flags as well as the severity level which say whether such
+ * \todo A function like perror that includes strerror output. Apache does this
+ * by adding flags as well as the severity level which say whether such
  * information should be included. */
 
 #include <inttypes.h>

--- a/src/tube.c
+++ b/src/tube.c
@@ -47,8 +47,8 @@
  *
  * \todo I think our current copy code will lock up if the application only
  * ever calls us with either input or output buffers, and not both.  So I guess
- * in that case we might need to copy into some temporary buffer space, and
- * then back out again later. */
+ * in that case we might need to copy into some temporary buffer space, and then
+ * back out again later. */
 
 #include "config.h"
 

--- a/src/tube.c
+++ b/src/tube.c
@@ -32,23 +32,23 @@
 /** \file tube.c A somewhat elastic but fairly small buffer for data passing
  * through a stream.
  *
- * In most cases the iter can adjust to send just as much data will fit.  In
+ * In most cases the iter can adjust to send just as much data will fit. In
  * some cases that would be too complicated, because it has to transmit an
- * integer or something similar.  So in that case we stick whatever won't fit
+ * integer or something similar. So in that case we stick whatever won't fit
  * into a small buffer.
  *
  * A tube can contain some literal data to go out (typically command bytes),
  * and also an instruction to copy data from the stream's input or from some
- * other location.  Both literal data and a copy command can be queued at the
+ * other location. Both literal data and a copy command can be queued at the
  * same time, but only in that order and at most one of each.
  *
- * \todo As an optimization, write it directly to the stream if possible.  But
+ * \todo As an optimization, write it directly to the stream if possible. But
  * for simplicity don't do that yet.
  *
  * \todo I think our current copy code will lock up if the application only
- * ever calls us with either input or output buffers, and not both.  So I guess
- * in that case we might need to copy into some temporary buffer space, and then
- * back out again later. */
+ * ever calls us with either input or output buffers, and not both. So I guess
+ * in that case we might need to copy into some temporary buffer space, and
+ * then back out again later. */
 
 #include "config.h"
 
@@ -191,8 +191,8 @@ int rs_tube_is_idle(rs_job_t const *job)
  *
  * We can only accept this request if there is no copy command already pending.
  *
- * \todo Try to do the copy immediately, and return a result.  Then, people can
- * try to continue if possible.  Is this really required? Callers can just go
+ * \todo Try to do the copy immediately, and return a result. Then, people can
+ * try to continue if possible. Is this really required? Callers can just go
  * out and back in again after flushing the tube. */
 void rs_tube_copy(rs_job_t *job, int len)
 {


### PR DESCRIPTION
Unfortunately indent's comment reformatting with -fca is not consistent, giving different results with repeated runs on the same input.

This removes the -fca argument from the make tidy target so that it doesn't introduce spurious comment changes every time it's run. If you really want to reformat comments use 'make tidyc', since tidyc now includes workarounds to make it consistent.

Reformat all the code again using 'make tidyc' using the latest tidyc with the consistency fix in it.