### PR TITLE
Fix memory leak on signature->block_sigs

### DIFF
--- a/src/sumset.c
+++ b/src/sumset.c
@@ -168,6 +168,8 @@ void rs_signature_done(rs_signature_t *sig)
 {
     hashtable_free(sig->hashtable);
     rs_bzero(sig, sizeof(*sig));
+
+    free(sig->block_sigs);
 }
 
 rs_block_sig_t *rs_signature_add_block(rs_signature_t *sig,

--- a/src/sumset.c
+++ b/src/sumset.c
@@ -167,9 +167,8 @@ rs_result rs_signature_init(rs_signature_t *sig, int magic, int block_len,
 void rs_signature_done(rs_signature_t *sig)
 {
     hashtable_free(sig->hashtable);
-    rs_bzero(sig, sizeof(*sig));
-
     free(sig->block_sigs);
+    rs_bzero(sig, sizeof(*sig));
 }
 
 rs_block_sig_t *rs_signature_add_block(rs_signature_t *sig,


### PR DESCRIPTION
I noticed that there was a memory leak on rs_job_iter, after investigating I found that it was not freeing memory hold by `rs_signature_t->block_sigs`. 

This patch fixed the memory leak.