### PR TITLE
Fix up doxygen comments.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,10 @@ latex
 Testing
 *.user
 
+# CMake generated Doxygen files
+CMakeDoxyfile.in
+CMakeDoxygenDefaults.cmake
+
 # Editor temp files
 .sw?
 .*.sw?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,17 +35,18 @@ The preferred style for docbook comments is javadoc with autobrief as
 follows;
 
 ```C
-/** \file file.c Brief summary paragraph.
+/** /file file.c
+  * Brief summary paragraph.
   *
   * With blank line paragraph delimiters and leading stars.
   *
-  * \param foo parameter descriptions...
+  * /param foo parameter descriptions...
   *
-  * \param bar ...in separate blank-line delimited paragraphs.
+  * /param bar ...in separate blank-line delimited paragraphs.
   *
-  * Example:\code
+  * Example:/code
   *  code blocks that will never be reformated.
-  * \endcode
+  * /endcode
   *
   * Without blank-line comment delimiters. */
 

--- a/src/buf.c
+++ b/src/buf.c
@@ -23,8 +23,8 @@
                                | Pick a window, Jimmy, you're leaving.
                                */
 
-/** \file buf.c Buffers that map between stdio file streams and librsync
- * streams.
+/** \file buf.c
+ * Buffers that map between stdio file streams and librsync streams.
  *
  * As the stream consumes input and produces output, it is refilled from
  * appropriate input and output FILEs. A dynamically allocated buffer of

--- a/src/command.h
+++ b/src/command.h
@@ -20,7 +20,8 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-/** \file command.h Types of commands present in the encoding stream.
+/** \file command.h
+ * Types of commands present in the encoding stream.
  *
  * The vague idea is that eventually this file will be more abstract than
  * protocol.h, but it's not clear that will ever be required. */

--- a/src/delta.c
+++ b/src/delta.c
@@ -26,8 +26,9 @@
                                  | MINING!!
                                  */
 
-/** \file delta.c -- Generate in streaming mode an rsync delta given a set of
- * signatures, and a new file.
+/** \file delta.c
+ * Generate in streaming mode an rsync delta given a set of signatures, and a
+ * new file.
  *
  * The size of blocks for signature generation is determined by the block size
  * in the incoming signature.

--- a/src/emit.c
+++ b/src/emit.c
@@ -19,7 +19,8 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-/** \file emit.c encoding output routines.
+/** \file emit.c
+ * encoding output routines.
  *
  * \todo Pluggable encoding formats: gdiff-style, rsync 24, ed (text), Delta
  * HTTP. */

--- a/src/emit.h
+++ b/src/emit.h
@@ -19,7 +19,8 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-/** \file emit.h How to emit commands to the client. */
+/** \file emit.h
+ * How to emit commands to the client. */
 
 void rs_emit_delta_header(rs_job_t *);
 void rs_emit_literal_cmd(rs_job_t *, int len);

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -23,7 +23,8 @@
 #  include <assert.h>
 #  include <stdlib.h>
 
-/** \file hashtable.h A generic open addressing hashtable.
+/** \file hashtable.h
+ * A generic open addressing hashtable.
  *
  * This is a minimal hashtable containing pointers to arbitrary entries with
  * configurable hashtable size and support for custom hash() and cmp() methods.

--- a/src/job.c
+++ b/src/job.c
@@ -25,7 +25,8 @@
                                | sheltering.
                                */
 
-/** \file job.c Generic state-machine interface.
+/** \file job.c
+ * Generic state-machine interface.
  *
  * The point of this is that we need to be able to suspend and resume
  * processing at any point at which the buffers may block.

--- a/src/job.h
+++ b/src/job.h
@@ -22,7 +22,7 @@
 #include "mdfour.h"
 #include "rollsum.h"
 
-/** \struct rs_job The contents of this structure are private. */
+/** The contents of this structure are private. */
 struct rs_job {
     int dogtag;
 

--- a/src/librsync.h
+++ b/src/librsync.h
@@ -27,8 +27,8 @@
                                |        -- Henrik Ibsen
                                */
 
-/** \file librsync.h Public header for librsync. */
-
+/** \file librsync.h
+ * Public header for librsync. */
 #ifndef _RSYNC_H
 #  define _RSYNC_H
 
@@ -108,7 +108,7 @@ typedef enum {
     RS_LOG_DEBUG = 7            /**< Debug-level messages */
 } rs_loglevel;
 
-/** \typedef rs_trace_fn_t Callback to write out log messages.
+/** Callback to write out log messages.
  *
  * \param level a syslog level.
  *
@@ -155,7 +155,7 @@ size_t rs_unbase64(char *s);
 /** Encode a buffer as base64. */
 void rs_base64(unsigned char const *buf, int n, char *out);
 
-/** \enum rs_result Return codes from nonblocking rsync operations.
+/** Return codes from nonblocking rsync operations.
  *
  * \sa rs_strerror() \sa api_callbacks */
 typedef enum rs_result {
@@ -211,9 +211,7 @@ typedef struct rs_stats {
     time_t start, end;
 } rs_stats_t;
 
-/** \typedef struct rs_mdfour rs_mdfour_t
- *
- * \brief MD4 message-digest accumulator.
+/** MD4 message-digest accumulator.
  *
  * \sa rs_mdfour(), rs_mdfour_begin(), rs_mdfour_update(), rs_mdfour_result() */
 typedef struct rs_mdfour rs_mdfour_t;
@@ -259,7 +257,7 @@ char *rs_format_stats(rs_stats_t const *stats, char *buf, size_t size);
  * \sa \ref api_stats \sa \ref api_trace */
 int rs_log_stats(rs_stats_t const *stats);
 
-/** \typedef rs_signature_t */
+/** The signature datastructure type. */
 typedef struct rs_signature rs_signature_t;
 
 /** Deep deallocation of checksums. */

--- a/src/mdfour.c
+++ b/src/mdfour.c
@@ -21,7 +21,8 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-/** \file mdfour.c MD4 message digest algorithm.
+/** \file mdfour.c
+ * MD4 message digest algorithm.
  *
  * \todo Perhaps use the MD4 routine from OpenSSL if it's installed. It's
  * probably not worth the trouble.
@@ -75,7 +76,9 @@ static void rs_mdfour_block(rs_mdfour_t *md, void const *p);
  * find an mdfour implementation already on the system (e.g. in OpenSSL) then
  * we should use it instead of our own?
  *
- * \param X A series of integer, read little-endian from the file. */
+ * \param *m An rs_mdfour_t instance to accumulate with.
+ *
+ * \param *p An array of uint32 integers, as read little-endian from the file. */
 static void rs_mdfour64(rs_mdfour_t *m, const void *p)
 {
     uint32_t AA, BB, CC, DD;

--- a/src/mksum.c
+++ b/src/mksum.c
@@ -20,7 +20,8 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-/** \file mksum.c Generate file signatures.
+/** \file mksum.c
+ * Generate file signatures.
  *
  * Generating checksums is pretty easy, since we can always just process
  * whatever data is available. When a whole block has arrived, or we've reached

--- a/src/msg.c
+++ b/src/msg.c
@@ -33,7 +33,8 @@
                                | Arco, and have a nice day.
                                */
 
-/** \file msg.c error messages for re_result values.
+/** \file msg.c
+ * error messages for re_result values.
  *
  * \todo (Suggestion by tridge) Add a function which outputs a complete text
  * description of a job, including only the fields relevant to the current

--- a/src/netint.c
+++ b/src/netint.c
@@ -27,7 +27,8 @@
                              |        -- Sun Microsystems
                              */
 
-/** \file netint.c Network-byte-order output to the tube.
+/** \file netint.c
+ * Network-byte-order output to the tube.
  *
  * All the `suck' routines return a result code. The most common values are
  * RS_DONE if they have enough data, or RS_BLOCKED if there is not enough input

--- a/src/prototab.c
+++ b/src/prototab.c
@@ -20,7 +20,8 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-/** \file prototab.c Delta file commands.
+/** \file prototab.c
+ * Delta file commands.
  *
  * This file defines an array mapping command IDs to the operation kind,
  * implied literal value, and length of the first and second parameters. The

--- a/src/prototab.h
+++ b/src/prototab.h
@@ -28,7 +28,8 @@
 				     |    -- http://abc.net.au/thegames/
 				     */
 
-/** \file prototab.h Delta file commands. */
+/** \file prototab.h
+ * Delta file commands. */
 
 typedef struct rs_prototab_ent {
     enum rs_op_kind kind;

--- a/src/rdiff.c
+++ b/src/rdiff.c
@@ -26,7 +26,8 @@
                                |              -- Harold Bloom
                                */
 
-/** \file rdiff.c -- Command-line network-delta tool.
+/** \file rdiff.c
+ * Command-line network-delta tool.
  *
  * \todo Add a -z option to gzip/gunzip patches. This would be somewhat useful,
  * but more importantly a good test of the streaming API. Also add -I for

--- a/src/readsums.c
+++ b/src/readsums.c
@@ -20,7 +20,8 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-/** \file readsums.c Load signatures from a file. */
+/** \file readsums.c
+ * Load signatures from a file. */
 
 #include "config.h"
 

--- a/src/scoop.c
+++ b/src/scoop.c
@@ -25,7 +25,8 @@
                                |   -- Shihad, `The General Electric'.
                                */
 
-/** \file scoop.c This file deals with readahead from caller-supplied buffers.
+/** \file scoop.c
+ * This file deals with readahead from caller-supplied buffers.
  *
  * Many functions require a certain minimum amount of input to do their
  * processing. For example, to calculate a strong checksum of a block we need
@@ -182,8 +183,12 @@ rs_result rs_scoop_readahead(rs_job_t *job, size_t len, void **ptr)
 
 /** Read LEN bytes if possible, and remove them from the input scoop.
  *
- * \param ptr will be updated to point to a read-only buffer holding the data,
- * if enough is available.
+ * \param *job An rs_job_t pointer to the job instance.
+ *
+ * \param len The length of the data in the ptr buffer.
+ *
+ * \param **ptr will be updated to point to a read-only buffer holding the
+ * data, if enough is available.
  *
  * \return RS_DONE if there was enough data, RS_BLOCKED if there was not enough
  * data yet, or RS_INPUT_ENDED if there was not enough data and at EOF. */
@@ -198,6 +203,8 @@ rs_result rs_scoop_read(rs_job_t *job, size_t len, void **ptr)
 }
 
 /** Read whatever data remains in the input stream.
+ *
+ * \param *job The rs_job_t instance the job instance.
  *
  * \param *len will be updated to the length of the available data.
  *

--- a/src/stats.c
+++ b/src/stats.c
@@ -17,7 +17,8 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-/** \file stats.c stats reporting functions.
+/** \file stats.c
+ * stats reporting functions.
  *
  * \todo Other things to show in statistics: number of input and output bytes,
  * number of times we blocked waiting for input or output, number of blocks. */

--- a/src/stream.c
+++ b/src/stream.c
@@ -27,7 +27,8 @@
                       |    -- Revised^5 Report on Scheme
                       */
 
-/** \file stream.c Manage librsync streams of IO.
+/** \file stream.c
+ * Manage librsync streams of IO.
  *
  * See \sa scoop.c and \sa tube.c for related code for input and output
  * respectively.

--- a/src/trace.c
+++ b/src/trace.c
@@ -26,7 +26,8 @@
                                       | There are lumps in it.
                                       */
 
-/** \file trace.c logging and debugging output.
+/** \file trace.c
+ * logging and debugging output.
  *
  * \todo Have a bit set in the log level that says not to include the function
  * name. */

--- a/src/trace.h
+++ b/src/trace.h
@@ -19,7 +19,8 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-/** \file trace.h logging functions.
+/** \file trace.h
+ * logging functions.
  *
  * trace may be turned off.
  *
@@ -90,8 +91,7 @@ enum {
     RS_LOG_NONAME = 8           /**< \b Don't show function name in message. */
 };
 
-/** \macro rs_trace_enabled()
- *
+/** \def rs_trace_enabled()
  * Call this before putting too much effort into generating trace messages. */
 
 extern int rs_trace_level;

--- a/src/tube.c
+++ b/src/tube.c
@@ -29,8 +29,9 @@
                                |   -- Popular Mechanics, March 1949
                                */
 
-/** \file tube.c A somewhat elastic but fairly small buffer for data passing
- * through a stream.
+/** \file tube.c
+ * A somewhat elastic but fairly small buffer for data passing through a
+ * stream.
  *
  * In most cases the iter can adjust to send just as much data will fit. In
  * some cases that would be too complicated, because it has to transmit an


### PR DESCRIPTION
This fixes some minor doxygen errors and warnings. The example generated docs can be seen at;

http://minkirri.apana.org.au/~abo/librsync

Running `make doc` is now completely error and warning free.