### PR TITLE
Fix #155 remove redundant and broken `--paranoia` option from rdiff.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,16 +6,27 @@ NOT RELEASED YET
 
  * Bump minor version from 2.0.3 to 2.1.0 to reflect additions to librsync.h.
 
- * Fix exporting of private symbols from librsync library (dbaarda,
-   https://github.com/librsync/librsync/issues/130).
+ * Fix exporting of private symbols from librsync library. Add export of
+   useful large file functions `rs_file_open()`, `rs_file_close()`, and
+   `rs_file_size()` to librsync.h. Add export of `rs_signature_log_stats()` to
+   log signature hashtable hit/miss stats. Improve rdiff error output.
+   (dbaarda, https://github.com/librsync/librsync/issues/130)
 
- * Add export of useful large file functions rs_file_open(), rs_file_close(),
-   and rs_file_size() to librsync.h.
+ * Updated release process to include stable tarballs. (dbaarda,
+   https://github.com/librsync/librsync/issues/146)
 
- * Add export of rs_signature_log_stats() to log signature hashtable hit/miss
-   stats.
+ * Remove redundant and broken `--paranoia` argument from rdiff. (dbaarda,
+   https://github.com/librsync/librsync/issues/155)
 
- * Improved rdiff error output.
+ * Fix memory leak of `rs_signature_t->block_sigs` when freeing signatures.
+   (telles-simbiose, https://github.com/librsync/librsync/pull/147)
+
+ * Document delta file format. (zmj,
+   https://github.com/librsync/librsync/issues/46)
+
+ * Fix up doxygen comments. (dbaarda,
+   https://github.com/librsync/librsync/pull/151)
+
 
 ## librsync 2.0.2
 

--- a/src/delta.c
+++ b/src/delta.c
@@ -103,9 +103,6 @@
 #include "trace.h"
 #include "rollsum.h"
 
-/* used by rdiff, but now redundant */
-LIBRSYNC_EXPORT int rs_roll_paranoia = 0;
-
 static rs_result rs_delta_s_scan(rs_job_t *job);
 static rs_result rs_delta_s_flush(rs_job_t *job);
 static rs_result rs_delta_s_end(rs_job_t *job);
@@ -129,7 +126,6 @@ static rs_result rs_delta_s_scan(rs_job_t *job)
     rs_long_t match_pos;
     size_t match_len;
     rs_result result;
-    Rollsum test;
 
     rs_job_check(job);
     /* read the input into the scoop */
@@ -149,18 +145,6 @@ static rs_result rs_delta_s_scan(rs_job_t *job)
             RollsumRotate(&job->weak_sum, job->scoop_next[job->scoop_pos],
                           job->scoop_next[job->scoop_pos + block_len]);
             result = rs_appendmiss(job, 1);
-            if (rs_roll_paranoia) {
-                RollsumInit(&test);
-                RollsumUpdate(&test, job->scoop_next + job->scoop_pos,
-                              block_len);
-                if (RollsumDigest(&test) != RollsumDigest(&job->weak_sum)) {
-                    rs_fatal("mismatch between rolled sum " FMT_WEAKSUM
-                             " and check " FMT_WEAKSUM "",
-                             RollsumDigest(&job->weak_sum),
-                             RollsumDigest(&test));
-                }
-
-            }
         }
     }
     /* if we completed OK */

--- a/src/librsync.h
+++ b/src/librsync.h
@@ -47,9 +47,6 @@ extern "C" {
  * \sa \ref versioning */
 extern char const rs_librsync_version[];
 
-/** Flag to turn on signature rollsum paranoia mode. */
-extern int rs_roll_paranoia;
-
 typedef uint8_t rs_byte_t;
 typedef intmax_t rs_long_t;
 

--- a/src/rdiff.c
+++ b/src/rdiff.c
@@ -92,7 +92,6 @@ const struct poptOption opts[] = {
     {"gzip", 'z', POPT_ARG_NONE, 0, OPT_GZIP},
     {"bzip2", 'i', POPT_ARG_NONE, 0, OPT_BZIP2},
     {"force", 'f', POPT_ARG_NONE, &file_force},
-    {"paranoia", 0, POPT_ARG_NONE, &rs_roll_paranoia},
     {0}
 };
 
@@ -138,7 +137,6 @@ static void help(void)
            "Delta-encoding options:\n"
            "  -b, --block-size=BYTES    Signature block size\n"
            "  -S, --sum-size=BYTES      Set signature strength\n"
-           "      --paranoia            Verify all rolling checksums\n"
            "IO options:\n" "  -I, --input-size=BYTES    Input buffer size\n"
            "  -O, --output-size=BYTES   Output buffer size\n"
            "  -z, --gzip[=LEVEL]        gzip-compress deltas\n"


### PR DESCRIPTION
This feature is redundant and broken, and is now causing more bugs than it is uncovering. Removing it.

This fixes #155 and simplifies the code a bit.

Also update NEWS.md with all changes since v2.0.2.