### PR TITLE
fix build on MinGW-w64 and MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,6 +260,7 @@ add_test(NAME hashtable_test COMMAND hashtable_test)
 add_executable(sumset_test
     tests/sumset_test.c src/sumset.c src/util.c src/trace.c src/hex.c
     src/checksum.c src/rollsum.c src/mdfour.c src/hashtable.c ${blake2_SRCS})
+target_compile_options(sumset_test PRIVATE -DLIBRSYNC_STATIC_DEFINE)
 target_link_libraries(sumset_test ${blake2_LIBS})
 add_test(NAME sumset_test COMMAND sumset_test)
 
@@ -361,7 +362,11 @@ set_target_properties(rsync PROPERTIES
     VERSION ${LIBRSYNC_VERSION}
     SOVERSION ${LIBRSYNC_MAJOR_VERSION}
     C_VISIBILITY_PRESET hidden)
-install(TARGETS rsync ${INSTALL_TARGETS_DEFAULT_ARGS} DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(TARGETS rsync ${INSTALL_TARGETS_DEFAULT_ARGS}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
 
 
 ########### next target ###############
@@ -378,7 +383,11 @@ if (BUILD_RDIFF)
     message (WARNING "Popt library is required for rdiff target")
   endif (POPT_FOUND)
 
-  install(TARGETS rdiff ${INSTALL_TARGETS_DEFAULT_ARGS} DESTINATION ${CMAKE_INSTALL_BINDIR})
+  install(TARGETS rdiff ${INSTALL_TARGETS_DEFAULT_ARGS}
+          RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+          LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+          ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  )
 endif (BUILD_RDIFF)
 
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@
 
 NOT RELEASED YET
 
+ * Fix MSVC builds by adding missing LIBRSYNC_EXPORT to variables in
+   librsync.h, add -DLIBRSYNC_STATIC_DEFINE to the sumset_test target,
+   and correctly install .dll files in the bin directory.
+   (adsun701, https://github.com/librsync/librsync/pull/161)
+
 ## librsync 2.1.0
 
 Released 2019-08-19

--- a/src/librsync.h
+++ b/src/librsync.h
@@ -45,7 +45,7 @@ extern "C" {
 /** Library version string.
  *
  * \sa \ref versioning */
-extern char const rs_librsync_version[];
+LIBRSYNC_EXPORT extern char const rs_librsync_version[];
 
 typedef uint8_t rs_byte_t;
 typedef intmax_t rs_long_t;
@@ -215,7 +215,7 @@ typedef struct rs_stats {
  * \sa rs_mdfour(), rs_mdfour_begin(), rs_mdfour_update(), rs_mdfour_result() */
 typedef struct rs_mdfour rs_mdfour_t;
 
-extern const int RS_MD4_SUM_LENGTH, RS_BLAKE2_SUM_LENGTH;
+LIBRSYNC_EXPORT extern const int RS_MD4_SUM_LENGTH, RS_BLAKE2_SUM_LENGTH;
 
 #  define RS_MAX_STRONG_SUM_LENGTH 32
 
@@ -493,7 +493,7 @@ LIBRSYNC_EXPORT rs_result rs_file_copy_cb(void *arg, rs_long_t pos, size_t *len,
  * The default 0 means use the recommended buffer size for the operation being
  * performed, any other value will override the recommended sizes. You probably
  * only need to change these in testing. */
-extern int rs_inbuflen, rs_outbuflen;
+LIBRSYNC_EXPORT extern int rs_inbuflen, rs_outbuflen;
 
 /** Generate the signature of a basis file, and write it out to another.
  *

--- a/src/librsync_export.h
+++ b/src/librsync_export.h
@@ -1,6 +1,9 @@
 #ifndef LIBRSYNC_EXPORT_H
 #  define LIBRSYNC_EXPORT_H
 
+#ifdef LIBRSYNC_STATIC_DEFINE
+#  define LIBRSYNC_EXPORT
+#else
 #  ifdef _WIN32
 #    ifdef rsync_EXPORTS
 #      define LIBRSYNC_EXPORT __declspec(dllexport)
@@ -10,5 +13,6 @@
 #  else
 #    define LIBRSYNC_EXPORT __attribute__((visibility("default")))
 #  endif
+#endif
 
 #endif                          /* LIBRSYNC_EXPORT_H */

--- a/src/rdiff.c
+++ b/src/rdiff.c
@@ -77,24 +77,6 @@ enum {
 
 char *rs_hash_name;
 
-const struct poptOption opts[] = {
-    {"verbose", 'v', POPT_ARG_NONE, 0, 'v'},
-    {"version", 'V', POPT_ARG_NONE, 0, 'V'},
-    {"input-size", 'I', POPT_ARG_INT, &rs_inbuflen},
-    {"output-size", 'O', POPT_ARG_INT, &rs_outbuflen},
-    {"hash", 'H', POPT_ARG_STRING, &rs_hash_name},
-    {"help", '?', POPT_ARG_NONE, 0, 'h'},
-    {0, 'h', POPT_ARG_NONE, 0, 'h'},
-    {"block-size", 'b', POPT_ARG_INT, &block_len},
-    {"sum-size", 'S', POPT_ARG_INT, &strong_len},
-    {"statistics", 's', POPT_ARG_NONE, &show_stats},
-    {"stats", 0, POPT_ARG_NONE, &show_stats},
-    {"gzip", 'z', POPT_ARG_NONE, 0, OPT_GZIP},
-    {"bzip2", 'i', POPT_ARG_NONE, 0, OPT_BZIP2},
-    {"force", 'f', POPT_ARG_NONE, &file_force},
-    {0}
-};
-
 static void rdiff_usage(const char *error, ...)
 {
     va_list va;
@@ -356,6 +338,25 @@ static rs_result rdiff_action(poptContext opcon)
 
 int main(const int argc, const char *argv[])
 {
+    /* Initialize opts at runtime to avoid unknown address values. */
+    const struct poptOption opts[] = {
+        {"verbose", 'v', POPT_ARG_NONE, 0, 'v'},
+        {"version", 'V', POPT_ARG_NONE, 0, 'V'},
+        {"input-size", 'I', POPT_ARG_INT, &rs_inbuflen},
+        {"output-size", 'O', POPT_ARG_INT, &rs_outbuflen},
+        {"hash", 'H', POPT_ARG_STRING, &rs_hash_name},
+        {"help", '?', POPT_ARG_NONE, 0, 'h'},
+        {0, 'h', POPT_ARG_NONE, 0, 'h'},
+        {"block-size", 'b', POPT_ARG_INT, &block_len},
+        {"sum-size", 'S', POPT_ARG_INT, &strong_len},
+        {"statistics", 's', POPT_ARG_NONE, &show_stats},
+        {"stats", 0, POPT_ARG_NONE, &show_stats},
+        {"gzip", 'z', POPT_ARG_NONE, 0, OPT_GZIP},
+        {"bzip2", 'i', POPT_ARG_NONE, 0, OPT_BZIP2},
+        {"force", 'f', POPT_ARG_NONE, &file_force},
+        {0}
+    };
+
     poptContext opcon;
     rs_result result;
 


### PR DESCRIPTION
This sets rsync_EXPORTS on Windows to prevent build failure. In addition, missing LIBRSYNC_EXPORT types are added to certain variables in librsync.h to prevent redefiniton errors on MSVC, and dlls are correctly installed into the bin directory.