### PR TITLE
Tidy hashtable.[ch] and make use of mix32() on hash keys optional.

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1945,7 +1945,7 @@ ENABLE_PREPROCESSING   = YES
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-MACRO_EXPANSION        = YES
+MACRO_EXPANSION        = NO
 
 # If the EXPAND_ONLY_PREDEF and MACRO_EXPANSION tags are both set to YES then
 # the macro expansion is limited to the macros specified with the PREDEFINED and
@@ -1953,7 +1953,7 @@ MACRO_EXPANSION        = YES
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_ONLY_PREDEF     = YES
+EXPAND_ONLY_PREDEF     = NO
 
 # If the SEARCH_INCLUDES tag is set to YES, the include files in the
 # INCLUDE_PATH will be searched if a #include is found.
@@ -1994,7 +1994,7 @@ PREDEFINED             = ENTRY=ENTRY KEY=KEY MATCH=MATCH NAME=NAME
 # definition found in the source code.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_AS_DEFINED      = _FUNC
+EXPAND_AS_DEFINED      =
 
 # If the SKIP_FUNCTION_MACROS tag is set to YES then doxygen's preprocessor will
 # remove all references to function-like macros that are alone on a line, have

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -64,26 +64,3 @@ void _hashtable_free(hashtable_t *t)
         free(t);
     }
 }
-
-void *_hashtable_iter(hashtable_iter_t *i, hashtable_t *t)
-{
-    assert(i != NULL);
-    assert(t != NULL);
-    i->htable = t;
-    i->index = 0;
-    return _hashtable_next(i);
-}
-
-void *_hashtable_next(hashtable_iter_t *i)
-{
-    assert(i->htable != NULL);
-    assert(i->index <= i->htable->size);
-    const hashtable_t *t = i->htable;
-    void *e;
-
-    while (i->index < t->size) {
-        if ((e = t->etable[i->index++]))
-            return e;
-    }
-    return NULL;
-}

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -34,12 +34,12 @@
  * data. The hash() function doesn't need to avoid clustering behaviour.
  *
  * It uses open addressing with quadratic probing for collisions. The
- * MurmurHash3 finalization function is optionally used on the hash() output
- * to avoid clustering and can be disabled by setting HASHTABLE_NMIX32. There
- * is no support for removing entries, only adding them. Multiple entries
- * with the same key can be added, and you can use a fancy cmp() function to
- * find particular entries by more than just their key. There is an iterator
- * for iterating through all entries in the hashtable. There are optional
+ * MurmurHash3 finalization function is optionally used on the hash() output to
+ * avoid clustering and can be disabled by setting HASHTABLE_NMIX32. There is
+ * no support for removing entries, only adding them. Multiple entries with the
+ * same key can be added, and you can use a fancy cmp() function to find
+ * particular entries by more than just their key. There is an iterator for
+ * iterating through all entries in the hashtable. There are optional
  * hashtable_find() find/match/hashcmp/entrycmp stats counters that can be
  * disabled by defining HASHTABLE_NSTATS.
  *
@@ -292,6 +292,7 @@ static inline ENTRY_T *_FUNC(_find) (hashtable_t *t, MATCH_T * m) {
 }
 
 static inline ENTRY_T *_FUNC(_next) (hashtable_t *t, int *i);
+
 /** Initialize a iteration and return the first entry.
  *
  * This works together with hashtable_next() for iterating through all entries
@@ -311,20 +312,25 @@ static inline ENTRY_T *_FUNC(_iter) (hashtable_t *t, int *i) {
     assert(t != NULL);
     assert(i != NULL);
     *i = 0;
-    return _FUNC(_next)(t, i);
+    return _FUNC(_next) (t, i);
 }
 
 /** Get the next entry from a hashtable iterator or NULL when finished.
  *
- * \param *i - the hashtable iterator to use.
+ * This works together with hashtable_iter() for iterating through all entries
+ * in a hashtable.
+ *
+ * \param *t - the hashtable to iterate over.
+ *
+ * \param *i - the int iterator index to use.
  *
  * \return The next entry or NULL if the iterator is finished. */
 static inline ENTRY_T *_FUNC(_next) (hashtable_t *t, int *i) {
     assert(t != NULL);
     assert(i != NULL);
-    ENTRY_T *e=NULL;
+    ENTRY_T *e = NULL;
 
-    while ((*i < t->size) && !(e = t->etable[(*i)++]));
+    while ((*i < t->size) && !(e = t->etable[(*i)++])) ;
     return e;
 }
 

--- a/tests/hashtable_test.c
+++ b/tests/hashtable_test.c
@@ -102,7 +102,7 @@ int main(int argc, char **argv)
 {
     /* Test mykey_hashtable instance. */
     hashtable_t *kt;
-    hashtable_iter_t ki;
+    int ki;
     mykey_t k1, k2;
 
     mykey_init(&k1, 1);
@@ -111,8 +111,8 @@ int main(int argc, char **argv)
     assert(mykey_hashtable_add(kt, &k1) == &k1);
     assert(mykey_hashtable_find(kt, &k1) == &k1);
     assert(mykey_hashtable_find(kt, &k2) == NULL);
-    assert(mykey_hashtable_iter(&ki, kt) == &k1);
-    assert(mykey_hashtable_next(&ki) == NULL);
+    assert(mykey_hashtable_iter(kt, &ki) == &k1);
+    assert(mykey_hashtable_next(kt, &ki) == NULL);
 
     /* Test myhashtable instance. */
     hashtable_t *t;
@@ -165,9 +165,9 @@ int main(int argc, char **argv)
 
     /* Test hashtable iterators */
     myentry_t *p;
-    hashtable_iter_t iter;
+    int iter;
     int count = 0;
-    for (p = myhashtable_iter(&iter, t); p != NULL; p = myhashtable_next(&iter)) {
+    for (p = myhashtable_iter(t, &iter); p != NULL; p = myhashtable_next(t, &iter)) {
         assert(p == &e || (&entry[0] <= p && p <= &entry[255]));
         count++;
     }


### PR DESCRIPTION
This simplifies the macro usage in hashtable.h to be less confusing and auto-format better.

It also adds support for turning off the mix32() finalizer, which is not necessary if your hash function already has good distribution characteristics (like RabinKarp does).