### PR TITLE
Use -1 for "unknown" for file sizes.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,12 +14,15 @@ NOT RELEASED YET
    and speeds up delta calculations. The rdiff cmd gets a new `-R
    (rollsum|rabinkarp)` argument with the default being `rabinkarp`, Use `-R
    rollsum` to generate backwards-compatible signatures. (dbaarda,
-   https://github.com/librsync/librsync/issues/3).
+   https://github.com/librsync/librsync/issues/3)
 
  * Use single-byte literal commands for small inserts in deltas. This makes
    each small insert use 1 less byte in deltas. (dbaarda,
    https://github.com/librsync/librsync/issues/120)
- 
+
+ * Change rs_file_size() to report -1 instead of 0 for unknown file sizes (not
+   a regular file). (dbaarda https://github.com/librsync/librsync/pull/168)
+
 ## librsync 2.1.0
 
 Released 2019-08-19

--- a/src/fileutil.c
+++ b/src/fileutil.c
@@ -123,7 +123,7 @@ rs_long_t rs_file_size(FILE *f)
     struct stat st;
     if ((fstat(fileno(f), &st) == 0) && (S_ISREG(st.st_mode)))
         return st.st_size;
-    return 0;
+    return -1;
 }
 
 rs_result rs_file_copy_cb(void *arg, rs_long_t pos, size_t *len, void **buf)

--- a/src/librsync.h
+++ b/src/librsync.h
@@ -499,7 +499,7 @@ LIBRSYNC_EXPORT int rs_file_close(FILE *file);
 /** Get the size of a file.
  *
  * This provides a platform independent way to get the size of large files. It
- * will return 0 if the size cannot be determined because it is not a regular
+ * will return -1 if the size cannot be determined because it is not a regular
  * file.
  *
  * \param file - the stdio file to get the size of. */

--- a/src/sumset.c
+++ b/src/sumset.c
@@ -151,7 +151,7 @@ rs_result rs_signature_init(rs_signature_t *sig, int magic, int block_len,
     /* Calculate the number of blocks if we have the signature file size. */
     /* Magic+header is 12 bytes, each block thereafter is 4 bytes
        weak_sum+strong_sum_len bytes */
-    sig->size = (int)(sig_fsize ? (sig_fsize - 12) / (4 + strong_len) : 0);
+    sig->size = (int)(sig_fsize < 12 ? 0 : (sig_fsize - 12) / (4 + strong_len));
     if (sig->size)
         sig->block_sigs =
             rs_alloc(sig->size * rs_block_sig_size(sig),

--- a/tests/sumset_test.c
+++ b/tests/sumset_test.c
@@ -43,7 +43,7 @@ int main(int argc, char **argv)
 
     /* Test rs_signature_init() */
     /* Default zero magic. */
-    res = rs_signature_init(&sig, 0, 16, 6, 0);
+    res = rs_signature_init(&sig, 0, 16, 6, -1);
     assert(res == RS_DONE);
     assert(sig.magic == RS_RK_BLAKE2_SIG_MAGIC);
     assert(sig.block_len == 16);
@@ -57,33 +57,37 @@ int main(int argc, char **argv)
 #endif
 
     /* Blake2 magic. */
-    res = rs_signature_init(&sig, RS_BLAKE2_SIG_MAGIC, 16, 6, 0);
+    res = rs_signature_init(&sig, RS_BLAKE2_SIG_MAGIC, 16, 6, -1);
     assert(res == RS_DONE);
     assert(sig.magic == RS_BLAKE2_SIG_MAGIC);
 
     /* MD4 magic. */
-    res = rs_signature_init(&sig, RS_MD4_SIG_MAGIC, 16, 6, 0);
+    res = rs_signature_init(&sig, RS_MD4_SIG_MAGIC, 16, 6, -1);
     assert(res == RS_DONE);
     assert(sig.magic == RS_MD4_SIG_MAGIC);
 
     /* RabinKarp + Blake2 magic. */
-    res = rs_signature_init(&sig, RS_RK_BLAKE2_SIG_MAGIC, 16, 6, 0);
+    res = rs_signature_init(&sig, RS_RK_BLAKE2_SIG_MAGIC, 16, 6, -1);
     assert(res == RS_DONE);
     assert(sig.magic == RS_RK_BLAKE2_SIG_MAGIC);
 
     /* RabinKarp + MD4 magic. */
-    res = rs_signature_init(&sig, RS_RK_MD4_SIG_MAGIC, 16, 6, 0);
+    res = rs_signature_init(&sig, RS_RK_MD4_SIG_MAGIC, 16, 6, -1);
     assert(res == RS_DONE);
     assert(sig.magic == RS_RK_MD4_SIG_MAGIC);
 
     /* Bad magic. */
-    res = rs_signature_init(&sig, 1, 16, 6, 0);
+    res = rs_signature_init(&sig, 1, 16, 6, -1);
     assert(res == RS_BAD_MAGIC);
 
     /* Bad strong_sum_len. */
-    res = rs_signature_init(&sig, RS_MD4_SIG_MAGIC, 16, 17, 0);
+    res = rs_signature_init(&sig, RS_MD4_SIG_MAGIC, 16, 17, -1);
     assert(res == RS_PARAM_ERROR);
-    res = rs_signature_init(&sig, RS_RK_MD4_SIG_MAGIC, 16, 17, 0);
+    res = rs_signature_init(&sig, RS_RK_MD4_SIG_MAGIC, 16, 17, -1);
+    assert(res == RS_PARAM_ERROR);
+    res = rs_signature_init(&sig, RS_BLAKE2_SIG_MAGIC, 16, 33, -1);
+    assert(res == RS_PARAM_ERROR);
+    res = rs_signature_init(&sig, RS_RK_BLAKE2_SIG_MAGIC, 16, 33, -1);
     assert(res == RS_PARAM_ERROR);
 
     /* With sig_fsize provided. */
@@ -102,16 +106,16 @@ int main(int argc, char **argv)
     assert(sig.block_sigs == NULL);
 
     /* Test rs_signature_calc_strong_sum(). */
-    res = rs_signature_init(&sig, RS_MD4_SIG_MAGIC, 16, 6, 0);
+    res = rs_signature_init(&sig, RS_MD4_SIG_MAGIC, 16, 6, -1);
     rs_signature_calc_strong_sum(&sig, &buf, 256, &strong);
     assert(memcmp(&strong, "\x29\x8a\x05\xbc\x50\x6e", 6) == 0);
 
-    res = rs_signature_init(&sig, RS_BLAKE2_SIG_MAGIC, 16, 6, 0);
+    res = rs_signature_init(&sig, RS_BLAKE2_SIG_MAGIC, 16, 6, -1);
     rs_signature_calc_strong_sum(&sig, &buf, 256, &strong);
     assert(memcmp(&strong, "\x39\xa7\xeb\x9f\xed\xc1", 6) == 0);
 
     /* Test rs_signature_add_block(). */
-    res = rs_signature_init(&sig, 0, 16, 6, 0);
+    res = rs_signature_init(&sig, 0, 16, 6, -1);
     rs_signature_add_block(&sig, weak, &strong);
     assert(sig.count == 1);
     assert(sig.size == 16);
@@ -122,7 +126,7 @@ int main(int argc, char **argv)
     rs_signature_done(&sig);
 
     /* Prepare rs_build_hash_table() and rs_signature_find_match() tests. */
-    res = rs_signature_init(&sig, 0, 16, 6, 0);
+    res = rs_signature_init(&sig, 0, 16, 6, -1);
     for (i = 0; i < 256; i += 16) {
         weak = rs_signature_calc_weak_sum(&sig, &buf[i], 16);
         rs_signature_calc_strong_sum(&sig, &buf[i], 16, &strong);


### PR DESCRIPTION
Change rs_file_size() to return -1 for unknown file sizes and update docstring in librsync.h. In sumset.c update rs_signature_init() work correctly for sig_fsize<12.

Update sumset_test.c to use -1 for unknown filesizes and add some tests for checking invalid blake2 strong_len arguments.