### PR TITLE
Add cmake BUILD_SHARED_LIBS option for static library support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ language: c
 before_script:
   - cmake --help
   - cmake $CMAKE_OPTIONS $CMAKE_GENERATOR .
-  
-sudo: required
 
 env:
   - CTEST_OUTPUT_ON_FAILURE=1
@@ -18,38 +16,36 @@ addons:
     - libpopt-dev
     - doxygen
     - ninja-build
+  homebrew:
+    packages:
+      - popt
 
 script:
   - make check
 
 matrix:
   include:
-    - compiler: clang
-      os: osx
-      before_install:
-        - brew update
-        - brew install popt
-      script:
-        - make check doc
+    - os: osx
+      compiler: clang
+      script: make check doc
 
-    - dist: xenial
-      sudo: false
+    - os: linux
+      compiler: gcc
 
-    - compiler: clang
-      dist: xenial
+    - os: linux
+      compiler: clang
 
-    - compiler: clang
+    - os: linux
+      compiler: clang
       env: CMAKE_GENERATOR="-G Ninja"
-      dist: xenial
-      script:
-        - ninja check doc
+      script: ninja check doc
 
-    - dist: xenial
-      sudo: false
+    - os: linux
+      compiler: gcc
+      env: CMAKE_OPTIONS="-D BUILD_SHARED_LIBS=OFF"
+
+    - os: linux
+      compiler: gcc
       env: CMAKE_OPTIONS="-D BUILD_RDIFF=OFF"
-
-
-# All tests are on xenial and OSX (which probably has older versions of
-# everything).
 
 # vim: shiftwidth=2 expandtab

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ matrix:
   include:
     - os: osx
       compiler: clang
-      script: make check doc
 
     - os: linux
       compiler: gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ addons:
   homebrew:
     packages:
       - popt
+    update: true
 
 script:
   - make check

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,8 @@ if (NOT CMAKE_SYSTEM_NAME)
 	message(FATAL_ERROR "No target OS set")
 endif()
 
+option(BUILD_SHARED_LIBS "Build librsync as a shared library." ON)
+
 set(DO_RS_TRACE 0)
 option(ENABLE_TRACE "Compile in detailed trace messages" OFF)
 if (ENABLE_TRACE)
@@ -355,7 +357,7 @@ set(rsync_LIB_SRCS
     src/whole.c
     ${blake2_SRCS})
 
-add_library(rsync SHARED ${rsync_LIB_SRCS})
+add_library(rsync ${rsync_LIB_SRCS})
 # TODO: Enable this when GenerateExportHeader works more widely.
 # include(GenerateExportHeader)
 # generate_export_header(rsync BASE_NAME librsync
@@ -373,10 +375,16 @@ if (ENABLE_COMPRESSION)
   endif (ZLIB_FOUND AND BZIP2_FOUND)
 endif (ENABLE_COMPRESSION)
 
+# Set properties/options for shared vs static library.
+if (BUILD_SHARED_LIBS)
+  set_target_properties(rsync PROPERTIES C_VISIBILITY_PRESET hidden)
+else (BUILD_SHARED_LIBS)
+  target_compile_options(rsync PUBLIC -DLIBRSYNC_STATIC_DEFINE)
+endif (BUILD_SHARED_LIBS)
+
 set_target_properties(rsync PROPERTIES
     VERSION ${LIBRSYNC_VERSION}
-    SOVERSION ${LIBRSYNC_MAJOR_VERSION}
-    C_VISIBILITY_PRESET hidden)
+    SOVERSION ${LIBRSYNC_MAJOR_VERSION})
 install(TARGETS rsync ${INSTALL_TARGETS_DEFAULT_ARGS}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,8 +20,17 @@ NOT RELEASED YET
    each small insert use 1 less byte in deltas. (dbaarda,
    https://github.com/librsync/librsync/issues/120)
 
+ * Fix multiple warnings (cross-)compiling for windows. (Adsun701,
+   https://github.com/librsync/librsync/pull/165,
+   https://github.com/librsync/librsync/pull/166)
+
  * Change rs_file_size() to report -1 instead of 0 for unknown file sizes (not
    a regular file). (dbaarda https://github.com/librsync/librsync/pull/168)
+
+ * Add cmake BUILD_SHARED_LIBS option for static library support.
+   BUILD_SHARED_LIBS defaults to ON, and can be set to OFF using `ccmake .` to
+   build librsync as a static library. (dbaarda
+   https://github.com/librsync/librsync/pull/169)
 
 ## librsync 2.1.0
 


### PR DESCRIPTION
BUILD_SHARED_LIBS defaults to ON, and can be set to OFF using `ccmake .` to
build librsync as a static library.