### PR TITLE
fix compilation with MS Visual Studio ad ignore build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ CMakeDoxygenDefaults.cmake
 
 # Test binaries
 *_test
+*_test.exe
+*_test.exe.manifest
 
 *.bak
 
@@ -60,3 +62,8 @@ doxygen_sqlite3.db
 .ninja_log
 build.ninja
 rules.ninja
+
+# Microsoft Visual Studio build files
+*.sln
+*.vcxproj
+*.vcxproj.filters

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -189,11 +189,11 @@ static inline unsigned mix32(unsigned int h)
 #  define NAME_iter _JOIN(NAME, _iter)
 #  define NAME_next _JOIN(NAME, _next)
 
-/* Modified hash() with/without mix32() and non-zero output. */
+/* Modified hash() with/without mix32(). */
 #  ifdef HASHTABLE_NMIX32
-#    define _KEY_HASH(k) ({unsigned hk=KEY_hash((KEY_t *)k); hk ? hk : -1;})
+#    define _KEY_HASH(k) KEY_hash((KEY_t *)k)
 #  else
-#    define _KEY_HASH(k) ({unsigned hk=mix32(KEY_hash((KEY_t *)k)); hk ? hk : -1;})
+#    define _KEY_HASH(k) mix32(KEY_hash((KEY_t *)k))
 #  endif
 
 /* Loop macro for probing table t for key k, setting hk to the hash for k
@@ -202,6 +202,7 @@ static inline unsigned mix32(unsigned int h)
 #  define _for_probe(t, k, hk, i, h) \
     const unsigned mask = t->size - 1;\
     unsigned hk = _KEY_HASH(k), i, s, h;\
+    if (hk == 0) hk = -1;\
     for (i = hk & mask, s = 0; (h = t->ktable[i]); i = (i + ++s) & mask)
 
 /* Conditional macro for incrementing stats counters. */


### PR DESCRIPTION
The Visual Studio C++ compiler seems not to like the current implementation of the `_KEY_HASH` macro. This pull request is aimed to restore compatibility with Microsoft Visual Studio 2019.

In addition, some wildcards are added to `.gitignore` targeting output files from CMake and from the build.