### PR TITLE
Fix #176 rs_int_len() for large values.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
 
 NOT RELEASED YET
 
+ * Fix #176 hangs calculating deltas for files larger than 4GB. (dbaarda,
+   https://github.com/librsync/librsync/pull/177)
+
 ## librsync 2.2.0
 
 Released 2019-10-12

--- a/src/netint.c
+++ b/src/netint.c
@@ -146,9 +146,12 @@ rs_result rs_suck_n4(rs_job_t *job, int *v)
 
 int rs_int_len(rs_long_t val)
 {
-    int i;
-
-    for (i = 8; val >> i; i *= 2) ;
-    assert(i <= 64);
-    return i / 8;
+    if (!(val & ~(rs_long_t)0xff))
+        return 1;
+    if (!(val & ~(rs_long_t)0xffff))
+	return 2;
+    if (!(val & ~(rs_long_t)0xffffffff))
+	return 4;
+    assert(!(val & ~(rs_long_t)0xffffffffffffffff));
+    return 8;
 }


### PR DESCRIPTION
This reverts this to what it was before, with some minor tidy ups. I believe
that this is pretty much the only way to make it work when rs_long_t is of an
unknown size. It's also pretty hard to write tests that will still pass on
platforms where rs_long_t is less than 64bits.