### PR TITLE
CMakeLists: fix build with old compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,7 @@ if (CMAKE_C_COMPILER_ID MATCHES "(Clang|Gnu|GNU)")
   # TODO: Set for MSVC and other compilers.
   # TODO: Set -Werror when the build is clean.
 
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -std=c99")
 endif()
 
 site_name(BUILD_HOSTNAME)


### PR DESCRIPTION
The librsync code uses some C99 constructs, but old compilers such
as gcc 4.7 don't default to -std=c99. This commit makes sure librsync
is built with -std=gnu99.

Fixes:

src/rabinkarp.h:82:5: error: ‘for’ loop initial declarations are only allowed in C99 or C11 mode
     for (size_t i = len; i; i--) {
     ^
src/rabinkarp.h:82:5: note: use option -std=c99, -std=gnu99, -std=c11 or -std=gnu11 to compile your code

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>