### PR TITLE
Simplify and tidy netint.[ch], tube.c and add netint tests.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,8 +238,12 @@ add_custom_target(tidyc
 
 add_executable(isprefix_test
     tests/isprefix_test.c src/isprefix.c)
-
 add_test(NAME isprefix_test COMMAND isprefix_test)
+
+add_executable(netint_test
+    tests/netint_test.c src/netint.c src/util.c src/trace.c src/tube.c
+    src/scoop.c src/stream.c)
+add_test(NAME netint_test COMMAND netint_test)
 
 add_executable(rollsum_test
     tests/rollsum_test.c src/rollsum.c)
@@ -292,8 +296,14 @@ else (BUILD_RDIFF)
   set(LAST_TARGET rsync)
 endif (BUILD_RDIFF)
 add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
-add_dependencies(check ${LAST_TARGET} isprefix_test rollsum_test rabinkarp_test hashtable_test checksum_test sumset_test)
-
+add_dependencies(check ${LAST_TARGET}
+    isprefix_test
+    netint_test
+    rollsum_test
+    rabinkarp_test
+    hashtable_test
+    checksum_test
+    sumset_test)
 
 enable_testing()
 

--- a/src/netint.c
+++ b/src/netint.c
@@ -69,7 +69,7 @@ rs_result rs_squirt_netint(rs_job_t *job, rs_long_t val, int len)
     assert(len <= RS_MAX_INT_BYTES);
     /* Fill the output buffer with a bigendian representation of the number. */
     for (i = len - 1; i >= 0; i--) {
-        buf[i] = val;             /* truncated */
+        buf[i] = val;           /* truncated */
         val >>= 8;
     }
     rs_tube_write(job, buf, len);

--- a/src/netint.h
+++ b/src/netint.h
@@ -20,12 +20,12 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-rs_result rs_squirt_byte(rs_job_t *job, rs_byte_t v);
-rs_result rs_squirt_netint(rs_job_t *job, rs_long_t v, int len);
-rs_result rs_squirt_n4(rs_job_t *job, int v);
+rs_result rs_squirt_byte(rs_job_t *job, rs_byte_t val);
+rs_result rs_squirt_netint(rs_job_t *job, rs_long_t val, int len);
+rs_result rs_squirt_n4(rs_job_t *job, int val);
 
-rs_result rs_suck_byte(rs_job_t *job, rs_byte_t *v);
-rs_result rs_suck_netint(rs_job_t *job, rs_long_t *v, int len);
-rs_result rs_suck_n4(rs_job_t *job, int *v);
+rs_result rs_suck_byte(rs_job_t *job, rs_byte_t *val);
+rs_result rs_suck_netint(rs_job_t *job, rs_long_t *val, int len);
+rs_result rs_suck_n4(rs_job_t *job, int *val);
 
-int rs_int_len(rs_long_t v);
+int rs_int_len(rs_long_t val);

--- a/src/netint.h
+++ b/src/netint.h
@@ -20,12 +20,12 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-rs_result rs_squirt_byte(rs_job_t *, unsigned char d);
-rs_result rs_squirt_netint(rs_job_t *, rs_long_t d, int len);
-rs_result rs_squirt_n4(rs_job_t *, int val);
+rs_result rs_squirt_byte(rs_job_t *job, rs_byte_t v);
+rs_result rs_squirt_netint(rs_job_t *job, rs_long_t v, int len);
+rs_result rs_squirt_n4(rs_job_t *job, int v);
 
-rs_result rs_suck_netint(rs_job_t *, rs_long_t *v, int len);
-rs_result rs_suck_byte(rs_job_t *, unsigned char *);
-rs_result rs_suck_n4(rs_job_t *, int *);
+rs_result rs_suck_byte(rs_job_t *job, rs_byte_t *v);
+rs_result rs_suck_netint(rs_job_t *job, rs_long_t *v, int len);
+rs_result rs_suck_n4(rs_job_t *job, int *v);
 
-int rs_int_len(rs_long_t val);
+int rs_int_len(rs_long_t v);

--- a/tests/netint_test.c
+++ b/tests/netint_test.c
@@ -1,0 +1,49 @@
+/*= -*- c-basic-offset: 4; indent-tabs-mode: nil; -*-
+ * librsync -- dynamic caching and delta update in HTTP
+ *
+ * Copyright (C) 2019 by Donovan Baarda <abo@minkirri.apana.org.au>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+/* Force DEBUG on so that tests can use assert(). */
+#undef NDEBUG
+#include <assert.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include "librsync.h"
+#include "netint.h"
+
+/* Test driver for netint. */
+int main(int argc, char **argv)
+{
+    assert(rs_int_len((rs_long_t)0) == 1);
+    assert(rs_int_len((rs_long_t)1) == 1);
+    assert(rs_int_len((rs_long_t)INT8_MAX) == 1);
+    assert(rs_int_len((rs_long_t)1 << 7) == 1);
+    assert(rs_int_len((rs_long_t)1 << 8) == 2);
+    assert(rs_int_len((rs_long_t)INT16_MAX) == 2);
+#ifdef INT32_MAX
+    assert(rs_int_len((rs_long_t)1 << 15) == 2);
+    assert(rs_int_len((rs_long_t)1 << 16) == 4);
+    assert(rs_int_len((rs_long_t)INT32_MAX) == 4);
+#endif
+#ifdef INT64_MAX
+    assert(rs_int_len((rs_long_t)1 << 31) == 4);
+    assert(rs_int_len((rs_long_t)1 << 32) == 8);
+    assert(rs_int_len((rs_long_t)INT64_MAX) == 8);
+#endif
+    return 0;
+}


### PR DESCRIPTION
Add tests/netint_test.c and CMakeLists.txt changes to test rs_int_len().

In netint.[ch] replace runtime checks for invalid arguments with assert()
statements and tidy the argument names, variable names, and ordering. Replace
`unsigned char` arguments with `rs_byte_t`. Add an assert to rs_int_len() to
require the argument is positive.

Simplify and tidy tube.c, making variable names and code structure more consistent. Replace a fatal runtime check that should never happen with an assert().