### PR TITLE
cmake/FindPOPT.cmake: Add PkgConfig support

### DIFF
--- a/cmake/FindPOPT.cmake
+++ b/cmake/FindPOPT.cmake
@@ -42,20 +42,27 @@ if (NOT POPT_FOUND)
   endif (NOT POPT_ROOT_DIR)
 
   ##_____________________________________________________________________________
-  ## Check for the header files
+  ## Check with PkgConfig (to retrieve static dependencies such as iconv)
+  find_package(PkgConfig QUIET)
+  pkg_search_module (POPT QUIET popt)
+  if (NOT POPT_FOUND)
 
-  find_path (POPT_INCLUDE_DIRS popt.h
-    HINTS ${POPT_ROOT_DIR} ${CMAKE_INSTALL_PREFIX} $ENV{programfiles}\\GnuWin32 $ENV{programfiles32}\\GnuWin32
-    PATH_SUFFIXES include
-    )
+    ##_____________________________________________________________________________
+    ## Check for the header files
 
-  ##_____________________________________________________________________________
-  ## Check for the library
+    find_path (POPT_INCLUDE_DIRS popt.h
+      HINTS ${POPT_ROOT_DIR} ${CMAKE_INSTALL_PREFIX} $ENV{programfiles}\\GnuWin32 $ENV{programfiles32}\\GnuWin32
+      PATH_SUFFIXES include
+      )
 
-  find_library (POPT_LIBRARIES popt
-    HINTS ${POPT_ROOT_DIR} ${CMAKE_INSTALL_PREFIX} $ENV{programfiles}\\GnuWin32 $ENV{programfiles32}\\GnuWin32
-    PATH_SUFFIXES lib
-    )
+    ##_____________________________________________________________________________
+    ## Check for the library
+
+    find_library (POPT_LIBRARIES popt
+      HINTS ${POPT_ROOT_DIR} ${CMAKE_INSTALL_PREFIX} $ENV{programfiles}\\GnuWin32 $ENV{programfiles32}\\GnuWin32
+      PATH_SUFFIXES lib
+      )
+  endif (POPT_FOUND)
 
   ##_____________________________________________________________________________
   ## Actions taken when all components have been found

--- a/cmake/FindPOPT.cmake
+++ b/cmake/FindPOPT.cmake
@@ -44,12 +44,16 @@ if (NOT POPT_FOUND)
   ##_____________________________________________________________________________
   ## Check with PkgConfig (to retrieve static dependencies such as iconv)
   find_package(PkgConfig QUIET)
-  pkg_search_module (POPT QUIET popt)
+  if (PKG_CONFIG_FOUND)
+    pkg_search_module (POPT QUIET popt)
+  endif (PKG_CONFIG_FOUND)
+  
+  ##_____________________________________________________________________________
+  ## Fallback to searching if PkgConfig didn't work.
   if (NOT POPT_FOUND)
 
     ##_____________________________________________________________________________
     ## Check for the header files
-
     find_path (POPT_INCLUDE_DIRS popt.h
       HINTS ${POPT_ROOT_DIR} ${CMAKE_INSTALL_PREFIX} $ENV{programfiles}\\GnuWin32 $ENV{programfiles32}\\GnuWin32
       PATH_SUFFIXES include
@@ -57,18 +61,19 @@ if (NOT POPT_FOUND)
 
     ##_____________________________________________________________________________
     ## Check for the library
-
     find_library (POPT_LIBRARIES popt
       HINTS ${POPT_ROOT_DIR} ${CMAKE_INSTALL_PREFIX} $ENV{programfiles}\\GnuWin32 $ENV{programfiles32}\\GnuWin32
       PATH_SUFFIXES lib
       )
+      
+    ##_____________________________________________________________________________
+    ## Check the libraries and include dirs and set POPT_FOUND.
+    FIND_PACKAGE_HANDLE_STANDARD_ARGS (POPT DEFAULT_MSG POPT_LIBRARIES POPT_INCLUDE_DIRS)
+  
   endif (POPT_FOUND)
 
   ##_____________________________________________________________________________
   ## Actions taken when all components have been found
-
-  FIND_PACKAGE_HANDLE_STANDARD_ARGS (POPT DEFAULT_MSG POPT_LIBRARIES POPT_INCLUDE_DIRS)
-
   if (POPT_FOUND)
     if (NOT POPT_FIND_QUIETLY)
       message (STATUS "Found components for POPT")
@@ -84,7 +89,6 @@ if (NOT POPT_FOUND)
 
   ##_____________________________________________________________________________
   ## Mark advanced variables
-
   mark_as_advanced (
     POPT_ROOT_DIR
     POPT_INCLUDE_DIRS


### PR DESCRIPTION
Add PkgConfig support to retrieve popt dependencies otherwise static
build can fail if popt has been linked with iconv:

```
[100%] Linking C executable rdiff
/home/buildroot/autobuild/instance-2/output-1/per-package/librsync/host/opt/ext-toolchain/bin/../lib/gcc/powerpc-buildroot-linux-uclibc/8.3.0/../../../../powerpc-buildroot-linux-uclibc/bin/ld: /home/buildroot/autobuild/instance-2/output-1/per-package/librsync/host/powerpc-buildroot-linux-uclibc/sysroot/usr/lib/libpopt.a(poptint.o): in function `POPT_fprintf':
poptint.c:(.text+0x34c): undefined reference to `libiconv_open
```

Fixes:
 - http://autobuild.buildroot.org/results/896e8e3efbedad90d66ae8c4e1e50f16206cab49

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>