### PR TITLE
fix various warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,14 +96,16 @@ check_type_size ( "unsigned long" SIZEOF_UNSIGNED_LONG )
 check_type_size ( "unsigned short" SIZEOF_UNSIGNED_SHORT )
 
 # Check for printf "%zu" size_t formatting support.
-if(CMAKE_CROSSCOMPILING)
+if(WIN32)
+  # CheckCSourceRuns checking for "%zu" succeeds but still gives warnings on win32.
+  set(HAVE_PRINTF_Z OFF)
+  # Not using unsupported %zu generates warnings about using %I64 with MinGW.
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-format")
+  message (STATUS "Compiling to Win32 - printf \"%zu\" size_t formatting support disabled")
+elseif(CMAKE_CROSSCOMPILING)
   # CheckCSourceRuns doesn't work when cross-compiling; assume C99 compliant support.
   set(HAVE_PRINTF_Z ON)
   message (STATUS "Cross compiling - assuming printf \"%zu\" size_t formatting support")
-elseif(WIN32)
-  # CheckCSourceRuns checking for "%zu" succeeds but still gives warnings on win32.
-  set(HAVE_PRINTF_Z OFF)
-  message (STATUS "Compiling to Win32 - printf \"%zu\" size_t formatting support disabled")
 else()
   include(CheckCSourceRuns)
   check_c_source_runs("#include <stdio.h>\nint main(){char o[8];sprintf(o, \"%zu\", (size_t)7);return o[0] != '7';}" HAVE_PRINTF_Z)
@@ -133,7 +135,6 @@ endif()
 if (CMAKE_C_COMPILER_ID MATCHES "(Clang|Gnu|GNU)")
   # TODO: Set for MSVC and other compilers.
   # TODO: Set -Werror when the build is clean.
-
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -std=c99 -pedantic")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,14 +96,14 @@ check_type_size ( "unsigned long" SIZEOF_UNSIGNED_LONG )
 check_type_size ( "unsigned short" SIZEOF_UNSIGNED_SHORT )
 
 # Check for printf "%zu" size_t formatting support.
-if(WIN32)
+if(CMAKE_CROSSCOMPILING)
+  # CheckCSourceRuns doesn't work when cross-compiling; assume C99 compliant support.
+  set(HAVE_PRINTF_Z ON)
+  message (STATUS "Cross compiling - assuming printf \"%zu\" size_t formatting support")
+elseif(WIN32)
   # CheckCSourceRuns checking for "%zu" succeeds but still gives warnings on win32.
   set(HAVE_PRINTF_Z OFF)
   message (STATUS "Compiling to Win32 - printf \"%zu\" size_t formatting support disabled")
-elseif(CMAKE_CROSSCOMPILING)
-  # CheckCSourceRuns doesn't work when cross-compiling.
-  set(HAVE_PRINTF_Z ON)
-  message (STATUS "Cross compiling - assuming printf \"%zu\" size_t formatting support")
 else()
   include(CheckCSourceRuns)
   check_c_source_runs("#include <stdio.h>\nint main(){char o[8];sprintf(o, \"%zu\", (size_t)7);return o[0] != '7';}" HAVE_PRINTF_Z)
@@ -134,7 +134,7 @@ if (CMAKE_C_COMPILER_ID MATCHES "(Clang|Gnu|GNU)")
   # TODO: Set for MSVC and other compilers.
   # TODO: Set -Werror when the build is clean.
 
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -std=c99 -pedantic -Wno-format")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -std=c99 -pedantic")
 endif()
 
 site_name(BUILD_HOSTNAME)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,7 @@ if (CMAKE_C_COMPILER_ID MATCHES "(Clang|Gnu|GNU)")
   # TODO: Set for MSVC and other compilers.
   # TODO: Set -Werror when the build is clean.
 
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -std=c99 -pedantic")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -std=c99 -pedantic -Wno-format")
 endif()
 
 site_name(BUILD_HOSTNAME)

--- a/cmake/FindPOPT.cmake
+++ b/cmake/FindPOPT.cmake
@@ -70,7 +70,7 @@ if (NOT POPT_FOUND)
     ## Check the libraries and include dirs and set POPT_FOUND.
     FIND_PACKAGE_HANDLE_STANDARD_ARGS (POPT DEFAULT_MSG POPT_LIBRARIES POPT_INCLUDE_DIRS)
   
-  endif (POPT_FOUND)
+  endif (NOT POPT_FOUND)
 
   ##_____________________________________________________________________________
   ## Actions taken when all components have been found

--- a/src/trace.c
+++ b/src/trace.c
@@ -62,12 +62,12 @@ static const char *rs_severities[] = {
  * perhaps, and an error dialog for a browser.
  *
  * \todo Do we really need such fine-grained control, or just yes/no tracing? */
-void rs_trace_to(rs_trace_fn_t *new_impl)
+LIBRSYNC_EXPORT void rs_trace_to(rs_trace_fn_t *new_impl)
 {
     rs_trace_impl = new_impl;
 }
 
-void rs_trace_set_level(rs_loglevel level)
+LIBRSYNC_EXPORT void rs_trace_set_level(rs_loglevel level)
 {
     rs_trace_level = level;
 }
@@ -102,12 +102,12 @@ void rs_log0(int level, char const *fn, char const *fmt, ...)
     va_end(va);
 }
 
-void rs_trace_stderr(rs_loglevel UNUSED(level), char const *msg)
+LIBRSYNC_EXPORT void rs_trace_stderr(rs_loglevel UNUSED(level), char const *msg)
 {
     fputs(msg, stderr);
 }
 
-int rs_supports_trace(void)
+LIBRSYNC_EXPORT int rs_supports_trace(void)
 {
 #ifdef DO_RS_TRACE
     return 1;


### PR DESCRIPTION
This suppresses some harmless warnings given when compiling on MinGW-w64 due to differences in formatting. It also fixes some "dllimport" warnings and corrects a conditional block in `cmake/FindPOPT.cmake`. 

Fixes #184.