### PR TITLE
buf: fix usage of size_t

### DIFF
--- a/src/buf.c
+++ b/src/buf.c
@@ -101,7 +101,7 @@ rs_result rs_infilebuf_fill(rs_job_t *job, rs_buffers_t *buf, void *opaque)
         return RS_DONE;
 
     len = fread(fb->buf, 1, fb->buf_len, f);
-    if (len <= 0) {
+    if (len == 0) {
         /* This will happen if file size is a multiple of input block len */
         if (feof(f)) {
             rs_trace("seen end of file on input");


### PR DESCRIPTION
This commit removes cppcheck "style" warning.

Fixes:

[src/buf.c:104]: (style) Checking if unsigned variable 'len' is less than zero.

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>