### PR TITLE
Improve hashtable performance.

### DIFF
--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -44,10 +44,12 @@ hashtable_t *_hashtable_new(int size)
     for (size2 = 1; size2 < size; size2 <<= 1) ;
     if (!(t = calloc(1, sizeof(hashtable_t)+ size2 * sizeof(unsigned))))
         return NULL;
+#ifndef HASHTABLE_NBLOOM
     if (!(t->bloom = calloc(size2 / 8, sizeof(unsigned char)))) {
         _hashtable_free(t);
         return NULL;
     }
+#endif
     if (!(t->etable = calloc(size2, sizeof(void *)))) {
         _hashtable_free(t);
         return NULL;
@@ -64,7 +66,9 @@ void _hashtable_free(hashtable_t *t)
 {
     if (t) {
         free(t->etable);
+#ifndef HASHTABLE_NBLOOM
         free(t->bloom);
+#endif
         free(t);
     }
 }

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -64,6 +64,7 @@ void _hashtable_free(hashtable_t *t)
 {
     if (t) {
         free(t->etable);
+        free(t->bloom);
         free(t);
     }
 }

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -44,8 +44,12 @@ hashtable_t *_hashtable_new(int size)
     for (size2 = 1; size2 < size; size2 <<= 1) ;
     if (!(t = calloc(1, sizeof(hashtable_t)+ size2 * sizeof(unsigned))))
         return NULL;
+    if (!(t->bloom = calloc(size2 / 8, sizeof(unsigned char)))) {
+        _hashtable_free(t);
+        return NULL;
+    }
     if (!(t->etable = calloc(size2, sizeof(void *)))) {
-        free(t);
+        _hashtable_free(t);
         return NULL;
     }
     t->size = size2;

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -29,8 +29,8 @@
    marker for an empty bucket to avoid checking for NULL in the element table.
    If we do get a hash value of zero, we -1 to wrap it around to 0xffff. */
 
-/* Use max 0.8 load factor to avoid bad open addressing performance. */
-#define HASHTABLE_LOADFACTOR_NUM 8
+/* Use max 0.7 load factor to avoid bad open addressing performance. */
+#define HASHTABLE_LOADFACTOR_NUM 7
 #define HASHTABLE_LOADFACTOR_DEN 10
 
 hashtable_t *_hashtable_new(int size)

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -45,7 +45,7 @@ hashtable_t *_hashtable_new(int size)
     if (!(t = calloc(1, sizeof(hashtable_t)+ size2 * sizeof(unsigned))))
         return NULL;
 #ifndef HASHTABLE_NBLOOM
-    if (!(t->bloom = calloc(size2 / 8, sizeof(unsigned char)))) {
+    if (!(t->kbloom = calloc(size2 / 8, sizeof(unsigned char)))) {
         _hashtable_free(t);
         return NULL;
     }
@@ -67,7 +67,7 @@ void _hashtable_free(hashtable_t *t)
     if (t) {
         free(t->etable);
 #ifndef HASHTABLE_NBLOOM
-        free(t->bloom);
+        free(t->kbloom);
 #endif
         free(t);
     }

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -323,6 +323,8 @@ static inline ENTRY_t *NAME_find(hashtable_t *t, MATCH_t *m)
             }
         }
     }
+    /* Also count the compare for the empty bucket. */
+    _stats_inc(t->hashcmp_count);
     return NULL;
 }
 


### PR DESCRIPTION
Add a simple/small k=1 bloom filter to the hashtable to reduce hashtable probing (and thrashing cpu memory cache) by more than 50%. It can be turned off by defining HASHTABLE_NBLOOM.

Reduce the max hashtable load factor from 80% to 70% to ensure that most hashtable probing for lookups is within the same 64 byte cache line.

Fix hashcmp_count stats to include comparing against empty buckets. Previously these were not counted, but still required a hashtable lookup. This will increase the hashcmp_count stats compared to previous versions, but with the new bloom filter we avoid many lookups entirely.

Slightly tidy the _for_probe() and _KEY_HASH() macro's using a nozero() static inline to reserve zero entries for empty buckets.

This improves delta performance by between 20%~40%, particularly for small blocksizes and large files.