### PR TITLE
Make bloom filter more effective.

### DIFF
--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -41,7 +41,7 @@ hashtable_t *_hashtable_new(int size)
     /* Adjust requested size to account for max load factor. */
     size = 1 + size * HASHTABLE_LOADFACTOR_DEN / HASHTABLE_LOADFACTOR_NUM;
     /* Use next power of 2 larger than the requested size and get mask bits. */
-    for (size2 = 1, bits2 = 0; size2 < size; size2 <<= 1, bits2++) ;
+    for (size2 = 2, bits2 = 1; size2 < size; size2 <<= 1, bits2++) ;
     if (!(t = calloc(1, sizeof(hashtable_t)+ size2 * sizeof(unsigned))))
         return NULL;
     if (!(t->etable = calloc(size2, sizeof(void *)))) {

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -130,6 +130,10 @@
 typedef struct hashtable {
     int size;                   /**< Size of allocated hashtable. */
     int count;                  /**< Number of entries in hashtable. */
+    unsigned tmask;             /**< Mask to get the hashtable index. */
+#  ifndef HASHTABLE_NBLOOM
+    unsigned bshift;            /**< Shift to get the bloomfilter index. */
+#  endif
 #  ifndef HASHTABLE_NSTATS
     /* The following are for accumulating NAME_find() stats. */
     long find_count;            /**< The count of finds tried. */
@@ -151,15 +155,15 @@ void _hashtable_free(hashtable_t *t);
 #  ifndef HASHTABLE_NBLOOM
 static inline void hashtable_setbloom(hashtable_t *t, const unsigned h)
 {
-    /* Mix upper 16 bits with lower 16 bits for a "different hash". */
-    const unsigned i = (h ^ (h >> 16)) & (t->size - 1);
+    /* Use upper bits for a "different hash". */
+    const unsigned i = h >> t->bshift;
     t->kbloom[i / 8] |= 1 << (i % 8);
 }
 
 static inline bool hashtable_getbloom(hashtable_t *t, const unsigned h)
 {
-    /* Mix upper 16 bits with lower 16 bits for a "different hash". */
-    const unsigned i = (h ^ (h >> 16)) & (t->size - 1);
+    /* Use upper bits for a "different hash". */
+    const unsigned i = h >> t->bshift;
     return (t->kbloom[i / 8] >> (i % 8)) & 1;
 }
 #  endif
@@ -225,9 +229,8 @@ static inline unsigned nozero(unsigned h)
 /* Loop macro for probing table t for key hash hk, iterating with index i and
    entry hash h, terminating at an empty bucket. */
 #  define _for_probe(t, hk, i, h) \
-    const unsigned mask = t->size - 1;\
     unsigned i, s, h;\
-    for (i = hk & mask, s = 0; (h = t->ktable[i]); i = (i + ++s) & mask)
+    for (i = hk & t->tmask, s = 0; (h = t->ktable[i]); i = (i + ++s) & t->tmask)
 
 /* Conditional macro for incrementing stats counters. */
 #  ifndef HASHTABLE_NSTATS

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -151,13 +151,15 @@ void _hashtable_free(hashtable_t *t);
 #  ifndef HASHTABLE_NBLOOM
 static inline void hashtable_setbloom(hashtable_t *t, const unsigned h)
 {
-    const unsigned i = h & (t->size - 1);
+    /* Mix upper 16 bits with lower 16 bits for a "different hash". */
+    const unsigned i = (h ^ (h >> 16)) & (t->size - 1);
     t->kbloom[i / 8] |= 1 << (i % 8);
 }
 
 static inline bool hashtable_getbloom(hashtable_t *t, const unsigned h)
 {
-    const unsigned i = h & (t->size - 1);
+    /* Mix upper 16 bits with lower 16 bits for a "different hash". */
+    const unsigned i = (h ^ (h >> 16)) & (t->size - 1);
     return (t->kbloom[i / 8] >> (i % 8)) & 1;
 }
 #  endif


### PR DESCRIPTION
Use the upper bits of the hash as the bloom filter index instead of using the lower bits used for the hashtable index.

This means we don't use the same index for the bloom filter and hashtable which ensures we don't always start probing the hashtable after bloom-filter hits at known non-empty entries. This is similar to using a "different hash" for each "k" of a bloom filter. The hashtable probes have a chance of immediately hitting an empty entry, significantly reducing the number of weaksum compares.

Also add tmask and bshift attributes to hashtable_t so we don't need to recalculate them for every probe.