### PR TITLE
Fix #198 and #199 broken cmake popt detection and use /bin/sh not /bin/bash.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@
 
 
 project(librsync C)
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.6)
 
 INCLUDE(CMakeDependentOption)
 include(GNUInstallDirs)
@@ -147,6 +147,8 @@ message (STATUS "CMAKE_SYSTEM = ${CMAKE_SYSTEM}")
 # Find POPT
 find_package(POPT)
 if (POPT_FOUND)
+  message (STATUS "POPT_INCLUDE_DIRS  = ${POPT_INCLUDE_DIRS}")
+  message (STATUS "POPT_LIBRARIES = ${POPT_LIBRARIES}")
   include_directories(${POPT_INCLUDE_DIRS})
 endif (POPT_FOUND)
 
@@ -158,16 +160,14 @@ cmake_dependent_option(BUILD_RDIFF "Whether or not to build rdiff executable" ON
 # Find BZIP
 find_package (BZip2)
 if (BZIP2_FOUND)
-  message (STATUS "Found components for BZIP2")
-  message (STATUS "BZIP2_INCLUDE_DIR  = ${BZIP2_INCLUDE_DIR}")
+  message (STATUS "BZIP2_INCLUDE_DIRS  = ${BZIP2_INCLUDE_DIRS}")
   message (STATUS "BZIP2_LIBRARIES = ${BZIP2_LIBRARIES}")
-  include_directories(${BZIP2_INCLUDE_DIR})
+  include_directories(${BZIP2_INCLUDE_DIRS})
 endif (BZIP2_FOUND)
 
 # Find ZLIB
 find_package (ZLIB)
 if (ZLIB_FOUND)
-  message (STATUS "Found components for ZLIB")
   message (STATUS "ZLIB_INCLUDE_DIRS  = ${ZLIB_INCLUDE_DIRS}")
   message (STATUS "ZLIB_LIBRARIES = ${ZLIB_LIBRARIES}")
   include_directories(${ZLIB_INCLUDE_DIRS})
@@ -176,7 +176,6 @@ endif (ZLIB_FOUND)
 # Find libb2
 find_package(libb2)
 if (LIBB2_FOUND)
-  message (STATUS "Found components for libb2")
   message (STATUS "LIBB2_INCLUDE_DIRS  = ${LIBB2_INCLUDE_DIRS}")
   message (STATUS "LIBB2_LIBRARIES = ${LIBB2_LIBRARIES}")
 endif (LIBB2_FOUND)

--- a/cmake/FindPOPT.cmake
+++ b/cmake/FindPOPT.cmake
@@ -1,4 +1,3 @@
-
 #--------------------------------------------------------------------------------
 # Copyright (C) 2012-2013, Lars Baehren <lbaehren@gmail.com>
 # Copyright (C) 2015 Adam Schubert <adam.schubert@sg1-game.net>
@@ -27,72 +26,54 @@
 
 # - Check for the presence of POPT
 #
+# The following vars can be set to change behaviour;
+#  POPT_ROOT_DIR - path hint for finding popt.
+#  POPT_INCLUDE_DIR - cached override for POPT_INCLUDE_DIRS.
+#  POPT_LIBRARY_RELEASE - cached override for POPT_LIBRARIES.
+#
 # The following variables are set when POPT is found:
 #  POPT_FOUND      = Set to true, if all components of POPT have been found.
-#  POPT_INCLUDE_DIRS   = Include path for the header files of POPT
-#  POPT_LIBRARIES  = Link these to use POPT
-#  POPT_LFLAGS     = Linker flags (optional)
+#  POPT_INCLUDE_DIRS   = Include path for the header files of POPT.
+#  POPT_LIBRARIES  = Link these to use POPT.
 
-
-INCLUDE(FindPackageHandleStandardArgs)
-if (NOT POPT_FOUND)
-
-  if (NOT POPT_ROOT_DIR)
-    set (POPT_ROOT_DIR ${CMAKE_INSTALL_PREFIX})
-  endif (NOT POPT_ROOT_DIR)
-
-  ##_____________________________________________________________________________
-  ## Check with PkgConfig (to retrieve static dependencies such as iconv)
-  find_package(PkgConfig QUIET)
-  if (PKG_CONFIG_FOUND)
-    pkg_search_module (POPT QUIET popt)
-  endif (PKG_CONFIG_FOUND)
-  
-  ##_____________________________________________________________________________
-  ## Fallback to searching if PkgConfig didn't work.
-  if (NOT POPT_FOUND)
-
-    ##_____________________________________________________________________________
-    ## Check for the header files
-    find_path (POPT_INCLUDE_DIRS popt.h
-      HINTS ${POPT_ROOT_DIR} ${CMAKE_INSTALL_PREFIX} $ENV{programfiles}\\GnuWin32 $ENV{programfiles32}\\GnuWin32
-      PATH_SUFFIXES include
-      )
-
-    ##_____________________________________________________________________________
-    ## Check for the library
-    find_library (POPT_LIBRARIES popt
-      HINTS ${POPT_ROOT_DIR} ${CMAKE_INSTALL_PREFIX} $ENV{programfiles}\\GnuWin32 $ENV{programfiles32}\\GnuWin32
-      PATH_SUFFIXES lib
-      )
-      
-    ##_____________________________________________________________________________
-    ## Check the libraries and include dirs and set POPT_FOUND.
-    FIND_PACKAGE_HANDLE_STANDARD_ARGS (POPT DEFAULT_MSG POPT_LIBRARIES POPT_INCLUDE_DIRS)
-  
-  endif (NOT POPT_FOUND)
-
-  ##_____________________________________________________________________________
-  ## Actions taken when all components have been found
+# Check with PkgConfig (to retrieve static dependencies such as iconv)
+find_package(PkgConfig)
+if (PKG_CONFIG_FOUND)
+  pkg_search_module (POPT QUIET IMPORTED_TARGET poptd)
   if (POPT_FOUND)
-    if (NOT POPT_FIND_QUIETLY)
-      message (STATUS "Found components for POPT")
-      message (STATUS "POPT_ROOT_DIR  = ${POPT_ROOT_DIR}")
-      message (STATUS "POPT_INCLUDE_DIRS  = ${POPT_INCLUDE_DIRS}")
-      message (STATUS "POPT_LIBRARIES = ${POPT_LIBRARIES}")
-    endif (NOT POPT_FIND_QUIETLY)
-  else (POPT_FOUND)
-    if (POPT_FIND_REQUIRED)
-      message (FATAL_ERROR "Could not find POPT!")
-    endif (POPT_FIND_REQUIRED)
+    # PkgConfig found it, set cached vars to use the imported target it created.
+    set(POPT_INCLUDE_DIR "" CACHE PATH "Path to headers for popt.")
+    set(POPT_LIBRARY_RELEASE PkgConfig::POPT CACHE FILEPATH "Path to library for popt.")
   endif (POPT_FOUND)
+endif (PKG_CONFIG_FOUND)
 
-  ##_____________________________________________________________________________
-  ## Mark advanced variables
-  mark_as_advanced (
-    POPT_ROOT_DIR
-    POPT_INCLUDE_DIRS
-    POPT_LIBRARIES
-    )
-
+# Fallback to searching for path and library if PkgConfig didn't work.
+if (NOT POPT_FOUND)
+  find_path (POPT_INCLUDE_DIR popt.h
+    HINTS ${POPT_ROOT_DIR} ${CMAKE_INSTALL_PREFIX} $ENV{programfiles}\\GnuWin32 $ENV{programfiles32}\\GnuWin32
+    PATH_SUFFIXES include)
+  find_library (POPT_LIBRARY_RELEASE popt
+    HINTS ${POPT_ROOT_DIR} ${CMAKE_INSTALL_PREFIX} $ENV{programfiles}\\GnuWin32 $ENV{programfiles32}\\GnuWin32
+    PATH_SUFFIXES lib)
 endif (NOT POPT_FOUND)
+
+# Check library and paths and set POPT_FOUND appropriately.
+INCLUDE(FindPackageHandleStandardArgs)
+if (TARGET "${POPT_LIBRARY_RELEASE}")
+  # The library is a taget created by PkgConfig.
+  FIND_PACKAGE_HANDLE_STANDARD_ARGS(POPT
+    REQUIRED_VARS POPT_LIBRARY_RELEASE
+    VERSION_VAR POPT_VERSION)
+else ()
+  # The library is a library file and header include path.
+  FIND_PACKAGE_HANDLE_STANDARD_ARGS(POPT DEFAULT_MSG POPT_LIBRARY_RELEASE POPT_INCLUDE_DIR)
+endif ()
+
+# Set output vars from auto-detected/cached vars.
+if (POPT_FOUND)
+  set(POPT_INCLUDE_DIRS "${POPT_INCLUDE_DIR}")
+  set(POPT_LIBRARIES "${POPT_LIBRARY_RELEASE}")
+endif (POPT_FOUND)
+
+# Mark cache vars as advanced.
+mark_as_advanced (POPT_INCLUDE_DIR POPT_LIBRARY_RELEASE)

--- a/cmake/FindPOPT.cmake
+++ b/cmake/FindPOPT.cmake
@@ -39,7 +39,7 @@
 # Check with PkgConfig (to retrieve static dependencies such as iconv)
 find_package(PkgConfig)
 if (PKG_CONFIG_FOUND)
-  pkg_search_module (POPT QUIET IMPORTED_TARGET poptd)
+  pkg_search_module (POPT QUIET IMPORTED_TARGET popt)
   if (POPT_FOUND)
     # PkgConfig found it, set cached vars to use the imported target it created.
     set(POPT_INCLUDE_DIR "" CACHE PATH "Path to headers for popt.")

--- a/cmake/Findlibb2.cmake
+++ b/cmake/Findlibb2.cmake
@@ -1,14 +1,24 @@
 # - Check for the presence of libb2
 #
+# The following vars can be set to change behaviour;
+#  LIBB2_INCLUDE_DIR - cached override for LIBB2_INCLUDE_DIRS.
+#  LIBB2_LIBRARY_RELEASE - cached override for LIBB2_LIBRARIES.
+#
 # The following variables are set when libb2 is found:
 #  LIBB2_FOUND = Set to true, if all components of libb2 have been found.
 #  LIBB2_INCLUDE_DIRS  = Include path for the header files of libb2.
 #  LIBB2_LIBRARIES = Link these to use libb2.
 
-find_path (LIBB2_INCLUDE_DIRS blake2.h)
-find_library (LIBB2_LIBRARIES b2)
+find_path (LIBB2_INCLUDE_DIR blake2.h)
+find_library (LIBB2_LIBRARY_RELEASE b2)
 
 INCLUDE(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS (LIBB2 DEFAULT_MSG LIBB2_LIBRARIES LIBB2_INCLUDE_DIRS)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS (LIBB2 DEFAULT_MSG LIBB2_LIBRARY_RELEASE LIBB2_INCLUDE_DIR)
 
-mark_as_advanced (LIBB2_INCLUDE_DIRS LIBB2_LIBRARIES)
+# Set output vars from auto-detected/cached vars.
+if (LIBB2_FOUND)
+  set(LIBB2_INCLUDE_DIRS "${LIBB2_INCLUDE_DIR}")
+  set(LIBB2_LIBRARIES "${LIBB2_LIBRARY_RELEASE}")
+endif (LIBB2_FOUND)
+
+mark_as_advanced (LIBB2_INCLUDE_DIR LIBB2_LIBRARY_RELEASE)

--- a/tests/rdiff_bad_option.sh
+++ b/tests/rdiff_bad_option.sh
@@ -1,4 +1,4 @@
-#! /bin/bash -ex
+#! /bin/sh -ex
 
 # librsync -- the library for network deltas
 


### PR DESCRIPTION
This should fix problems on FreeBSD with cmake's popt detection and running tests without needing /bin/bash.

This fixes our cmake/FindPOPT.cmake by copying official FindPackage() examples and following the instructions for correctly using PkgConfig found here;

https://stackoverflow.com/questions/29191855/what-is-the-proper-way-to-use-pkg-config-from-cmake

It also updates cmake/Findlibb2.cmake to follow best practices better, and cleans our FindPackage() handling in CMakeLists.txt.

Finally, it fixes the only test script we had using `#!/bin/bash` to use `#!/bin/sh` instead. Apparently FreeBSD doesn't have bash installed by default, and this script doesn't need bash anyway.