### PR TITLE
Fix patch bug for zero-length copies and improve bad copy_cb() handling.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,12 @@
 
 NOT RELEASED YET
 
+ * Fix a bug so patch will now fail returning RS_CORRUPT on encountering a
+   zero length copy command instead of hanging. Make copy_cb() copying more
+   data than requested an assert-fail on debug builds, and a log-warning for
+   release builds. Make trace output a little less spammy about copy_cb()
+   return values. (dbaarda, https://github.com/librsync/librsync/pull/206)
+
 ## librsync 2.3.1
 
 Released 2020-05-19

--- a/src/sumset.c
+++ b/src/sumset.c
@@ -172,10 +172,9 @@ rs_result rs_sig_args(rs_long_t old_fsize, rs_magic_number * magic,
     else if (*strong_len == -1)
         *strong_len = min_strong_len;
     else if (old_fsize >= 0 && *strong_len < min_strong_len) {
-        rs_log(RS_LOG_WARNING,
-               "strong_len=" FMT_SIZE " smaller than recommended minimum "
-               FMT_SIZE " for old_fsize=" FMT_LONG " with block_len=" FMT_SIZE,
-               *strong_len, min_strong_len, old_fsize, *block_len);
+        rs_warn("strong_len=" FMT_SIZE " smaller than recommended minimum "
+                FMT_SIZE " for old_fsize=" FMT_LONG " with block_len=" FMT_SIZE,
+                *strong_len, min_strong_len, old_fsize, *block_len);
     } else if (*strong_len > max_strong_len) {
         rs_error("invalid strong_len=" FMT_SIZE " for magic=%#x", *strong_len,
                  (int)*magic);

--- a/src/trace.h
+++ b/src/trace.h
@@ -71,6 +71,7 @@ void rs_log0(int level, char const *fn, char const *fmt, ...)
 #endif                          /* !DO_RS_TRACE */
 
 #define rs_log(l, ...) rs_log0((l), __func__, __VA_ARGS__)
+#define rs_warn(...) rs_log0(RS_LOG_WARNING, __func__, __VA_ARGS__)
 #define rs_error(...) rs_log0(RS_LOG_ERR,  __func__, __VA_ARGS__)
 #define rs_fatal(...) do { \
     rs_log0(RS_LOG_CRIT, __func__, __VA_ARGS__); \


### PR DESCRIPTION
Fix a bug which would make librsync patch hang for a corrupt delta containing a zero-length copy command. Patch will now fail returning RS_CORRUPT on encountering a zero length copy command.

Make rs_patch_s_copying() do assert() that copy_cb() didn't copy more data than requested so that debug builds highlight this API violation. Keep the backwards-compatible defensive behavior of only copying the amount requested for non-debug builds, but upgrade the (possibly disabled) trace about it to log warning. Fix the rs_trace() of "copy callback returned ..." to only output this trace if the copy_cb() failed.

Tidy rs_patch_s_literal() and rs_patch_s_copy() code for updating stats to make them consistent.

Add rs_warn() to trace.h to make it easier to log warnings.