### PR TITLE
Add support for delta callback API.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -338,6 +338,7 @@ set(rsync_LIB_SRCS
     src/checksum.c
     src/command.c
     src/delta.c
+    src/deltagen.c
     src/emit.c
     src/fileutil.c
     src/hashtable.c

--- a/src/deltagen.c
+++ b/src/deltagen.c
@@ -1,0 +1,252 @@
+/*= -*- c-basic-offset: 4; indent-tabs-mode: nil; -*-
+ *
+ * deltagen.h -- a basic delta generator.
+ *
+ * Copyright (C) 2020 by Donovan Baarda <abo@minkirri.apana.org.au>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA. */
+#include "config.h"
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include "deltagen.h"
+#include "util.h"
+#include "emit.h"
+#include "job.h"
+#include "stream.h"
+#include "command.h"
+#include "prototab.h"
+#include "trace.h"
+
+rs_deltagen_t *rs_deltagen_new(void *out, rs_send_t *send)
+{
+    rs_deltagen_t *gen = rs_alloc_struct(rs_deltagen_t);
+
+    gen->out = out;
+    gen->send = send;
+    return gen;
+}
+
+void rs_deltagen_free(rs_deltagen_t *gen)
+{
+    free(gen);
+}
+
+/* Macro for a deltagen to try send and return on errors or blocked. */
+#define TRY_DELTAGEN_SEND(len, buf, ret) \
+   if ((ret = gen->send(gen->out, len, buf)) <= 0) \
+       return ret
+
+/* Macro for a deltagen to try mark and return on errors or blocked. */
+#define TRY_DELTAGEN_MARK(mark, ret) \
+   if ((ret = rs_deltagen_mark(gen, mark)) <= 0) \
+       return ret
+
+static inline int rs_deltagen_data(rs_deltagen_t *gen, rs_long_t pos, int len,
+                                   const void *buf)
+{
+    int sent_len;
+
+    rs_trace("rs_deltagen_data(pos=" FMT_LONG
+             ", len=%d) with cmd_len=%d data_len=%d", pos, len, gen->cmd_len,
+             gen->data_len);
+    if (!gen->data_len) {
+        /* This call is a new call with no incomplete calls pending. */
+        gen->data_pos = pos;
+        gen->data_len = len;
+    } else if (len < 0 && gen->data_len == RS_SEND_SYNC) {
+        /* This is a retry of a mark that needs a followup sync. */
+        len = RS_SEND_SYNC;
+    }
+    /* The pos and len arguments must match any pending calls. */
+    assert(gen->data_pos == pos);
+    assert(gen->data_len == len);
+    /* Send init marks before commands. */
+    if (len == RS_SEND_INIT) {
+        TRY_DELTAGEN_SEND(len, NULL, sent_len);
+        /* After init mark sent, change mark to sync to flush the header. */
+        len = gen->data_len = RS_SEND_SYNC;
+    }
+    /* If there's stuff in the cmd buffer, send it. */
+    if (gen->cmd_len) {
+        TRY_DELTAGEN_SEND(gen->cmd_len, gen->cmd_buf, sent_len);
+        gen->cmd_len -= sent_len;
+        /* If some is left, shuffle it to the front and return blocked. */
+        if (gen->cmd_len) {
+            memmove(gen->cmd_buf, gen->cmd_buf + sent_len, gen->cmd_len);
+            return 0;
+        }
+    }
+    if (len < 0) {
+        /* Send mark. */
+        TRY_DELTAGEN_SEND(len, NULL, sent_len);
+        assert(gen->data_pos == 0);
+        gen->data_len = 0;
+    } else if (len > 0) {
+        /* Send data. */
+        TRY_DELTAGEN_SEND(len, buf, sent_len);
+        gen->data_pos += sent_len;
+        gen->data_len -= sent_len;
+    } else {
+        /* There was no mark or data to send. */
+        sent_len = 0;
+    }
+    return sent_len;
+}
+
+int rs_deltagen_mark(rs_deltagen_t *gen, int mark)
+{
+    rs_trace("rs_deltagen_mark(mark=%d) with cmd_len=%d, data_len=%d", mark,
+             gen->cmd_len, gen->data_len);
+    /* If this is a retry of a pending mark, just finish sending it. */
+    if (gen->data_len) {
+        assert(gen->data_len == mark || gen->data_len == RS_SEND_SYNC);
+        return rs_deltagen_data(gen, 0, mark, NULL);
+    }
+    /* There should be nothing pending if this is not a retry. */
+    assert(gen->cmd_len == 0);
+    assert(gen->data_len == 0);
+    /* If we have a previous accumulated match, queue and clear it. */
+    if (gen->match_len) {
+        gen->cmd_len =
+            rs_put_copy_cmd(gen->match_pos, gen->match_len, gen->cmd_buf);
+        gen->match_len = 0;
+    }
+    /* Handle sending headers/footers. */
+    if (mark == RS_SEND_INIT) {
+        /* There is nothing queued before init. */
+        gen->cmd_len = rs_put_delta_header(gen->cmd_buf);
+    } else if (mark == RS_SEND_DONE) {
+        /* Note this could be appended after a queued match cmd. */
+        gen->cmd_len += rs_put_end_cmd(gen->cmd_buf + gen->cmd_len);
+    } else {
+        assert(mark == RS_SEND_SYNC);
+        /* There is no cmd data for a sync. */
+    }
+    return rs_deltagen_data(gen, 0, mark, NULL);
+}
+
+int rs_deltagen_match(rs_deltagen_t *gen, rs_long_t pos, int len,
+                      const void *buf)
+{
+    int sent_len;
+
+    rs_trace("rs_deltagen match(pos= " FMT_LONG " len=%d)", pos, len);
+    /* if last was a match that can be extended, extend it */
+    if (gen->match_len && (gen->match_pos + gen->match_len) == pos) {
+        gen->match_len += (rs_long_t)len;
+    } else {
+        /* Sync to flush any previously accumulated match. */
+        TRY_DELTAGEN_MARK(RS_SEND_SYNC, sent_len);
+        /* make this the new match value */
+        gen->match_pos = pos;
+        gen->match_len = len;
+    }
+    return len;
+}
+
+int rs_deltagen_miss(rs_deltagen_t *gen, rs_long_t pos, int len,
+                     const void *buf)
+{
+    int sent_len;
+
+    rs_trace("rs_deltagen miss(pos=" FMT_LONG " len=%d)", pos, len);
+    /* Flush any pending accumulted match and its sync mark first. */
+    if (gen->match_len || gen->data_len == RS_SEND_SYNC)
+        TRY_DELTAGEN_MARK(RS_SEND_SYNC, sent_len);
+    /* If there is no pending miss output, emit the literal cmd. */
+    if (!gen->data_len) {
+        /* This could be appended after a queued match cmd. */
+        gen->cmd_len += rs_put_literal_cmd(len, gen->cmd_buf + gen->cmd_len);
+    }
+    return rs_deltagen_data(gen, pos, len, buf);
+}
+
+int rs_buffers_send(rs_buffers_t *buffers, int len, const void *buf)
+{
+    rs_trace("rs_buffer_send(len=%d, buffers(avail_out=%d))", len,
+             (int)buffers->avail_out);
+    /* There is never anything to flush. */
+    if (len < 0)
+        return 1;
+    if (len > buffers->avail_out)
+        len = (int)buffers->avail_out;
+    if (len) {
+        memcpy(buffers->next_out, buf, (size_t)len);
+        buffers->next_out += len;
+        buffers->avail_out -= len;
+    }
+    return len;
+}
+
+int rs_jobstream_send(rs_job_t *job, int len, const void *buf)
+{
+    return rs_buffers_send(job->stream, len, buf);
+}
+
+/* A rs_send_t function that can write to a filo. */
+int rs_file_send(FILE *file, int len, const void *buf)
+{
+    int sent_len;
+
+    /* If len is a flush code, just return success. */
+    if (len < 0)
+        return 1;
+    /* write the data and return an error code if it didn't all get sent. */
+    sent_len = (int)fwrite(buf, 1, len, file);
+    return (sent_len != len) ? -errno : sent_len;
+}
+
+void rs_bufout_init(rs_bufout_t *bufout, void *out, rs_send_t *send)
+{
+    bufout->out = out;
+    bufout->send = send;
+    bufout->len = 0;
+}
+
+/* Macro for bufout to try send and return on errors or blocked. */
+#define TRY_BUFOUT_SEND(len, buf, ret) \
+   if ((ret = bufout->send(bufout->out, len, buf)) <= 0) \
+       return ret
+
+int rs_bufout_send(rs_bufout_t *bufout, int len, const void *buf)
+{
+    int sent_len;
+
+    rs_trace("rs_bufout_send(len=%d) with len=%d in buffer", len, bufout->len);
+    /* If there is data in the buffer, try to write it first. */
+    if (bufout->len) {
+        rs_trace("Calling send(len=%d, bufout->buf)", bufout->len);
+        TRY_BUFOUT_SEND(bufout->len, bufout->buf, sent_len);
+        bufout->len -= sent_len;
+        /* If some is left, shuffle it to the front and return blocked. */
+        if (bufout->len) {
+            memmove(bufout->buf, bufout->buf + sent_len, bufout->len);
+            return 0;
+        }
+    }
+    assert(bufout->len == 0);
+    /* Try to send the request. */
+    rs_trace("Calling send(len=%d, buf)", len);
+    TRY_BUFOUT_SEND(len, buf, sent_len);
+    /* If any data left would fit in the buffer, append it. */
+    if (len > 0 && (len -= sent_len) <= RS_BUFOUT_LEN) {
+        memcpy(bufout->buf, (rs_byte_t *)buf + sent_len, len);
+        bufout->len = len;
+        sent_len += len;
+    }
+    return sent_len;
+}

--- a/src/deltagen.h
+++ b/src/deltagen.h
@@ -1,0 +1,139 @@
+/*= -*- c-basic-offset: 4; indent-tabs-mode: nil; -*-
+ *
+ * deltagen.h -- a basic delta generator.
+ *
+ * Copyright (C) 2020 by Donovan Baarda <abo@minkirri.apana.org.au>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA. */
+#ifndef _DELTAGEN_H_
+#  define _DELTAGEN_H_
+
+#  include "librsync.h"
+
+/** Special constants for rs_send_t and rs_genmark_t arguments for flushing. */
+#  define RS_SEND_INIT -1
+#  define RS_SEND_SYNC -2
+#  define RS_SEND_DONE -3
+
+/** Function type for writing data.
+ *
+ * This can be used for writing data to an output. They should return the
+ * amount of data actually transferred, which must be less than or equal to the
+ * length requested. A zero return value indicates output is blocked. A
+ * negative return value indicates an error (usually negative errno.h values).
+ *
+ * When sending data, len can be a special negative RS_SEND_* value to flush
+ * accumulated data to initialize, synchronise, or finalize the output. When
+ * len is negative the return value will be zero if the flush didn't finish,
+ * positive if flushing completed, or negative for errors. The flush should be
+ * called repeatedly until it returns non-zero to ensure it completes. Flush
+ * operations should idempotent once they complete (additional calls do nothing
+ * extra).
+ *
+ * /param obj - the reader/writer/getter/putter object to use.
+ *
+ * /param len - the amount of data to transfer or negative flush code.
+ *
+ * /param *buf - the data buffer to transfer to/from, ignored for flushes. */
+typedef int rs_send_t(void *obj, int len, const void *buf);
+
+/** Callback type used for generating a "mark" output for a delta.
+ *
+ * These are used for emitting "events" into the delta output like init, sync,
+ * and done markers. The `mark` argument should be set to a RS_SEND_* value.
+ *
+ * \param gen - the delta generator object.
+ *
+ * \param mark - the event marker type.
+ *
+ * \returns - positive for success, zero for blocked (try again), or negative
+ * for errors. */
+typedef int rs_genmark_t(void *gen, int mark);
+
+/** Callback types used for creating or applying hit/miss data.
+ *
+ * These are used both to "write" hit/miss data into a delta output, and to
+ * "read" copy data when doing a patch.
+ *
+ * \param gen - the delta generator object.
+ *
+ * \param pos - Position where the match/miss/get/put is.
+ *
+ * \param len - Length of match/miss/get/put data.
+ *
+ * \param buf - Data for the match/miss/get/put.
+ *
+ * \returns - Count of data actually processed, or negative values for errors. */
+typedef int rs_gendata_t(void *gen, rs_long_t pos, int len, const void *buf);
+
+/** A delta generator that generates a standard librsync delta. */
+typedef struct rs_deltagen_s {
+    void *out;                  /**< The writer object to use. */
+    rs_send_t *send;            /**< The send function to use. */
+    rs_long_t match_pos;        /**< The last accumulated match position. */
+    rs_long_t match_len;        /**< The last accumulated match length. */
+    rs_long_t data_pos;         /**< The data position left to output. */
+    int data_len;               /**< The data length left to output. */
+    int cmd_len;                /**< The cmd length to send. */
+    rs_byte_t cmd_buf[64];      /**< The cmd buffer to send. */
+} rs_deltagen_t;
+rs_deltagen_t *rs_deltagen_new(void *out, rs_send_t send);
+void rs_deltagen_free(rs_deltagen_t *gen);
+int rs_deltagen_mark(rs_deltagen_t *gen, int mark);
+int rs_deltagen_match(rs_deltagen_t *gen, rs_long_t pos, int len,
+                      const void *buf);
+int rs_deltagen_miss(rs_deltagen_t *gen, rs_long_t pos, int len,
+                     const void *buf);
+
+/** An rs_send_t function for writing data to a rs_buffers_t. */
+int rs_buffers_send(rs_buffers_t *buffers, int len, const void *buf);
+
+/** An rs_send_t function for writing data to a job's stream. */
+int rs_jobstream_send(rs_job_t *job, int len, const void *buf);
+
+/* A rs_send_t function that can write to a filo. */
+int rs_file_send(FILE *out, int len, const void *buf);
+
+#  define RS_BUFOUT_LEN 64
+/** An output writer that wraps another writer and adds a buffer.
+ *
+ * This writer adds a small buffer to guarantee that writes smaller than 64
+ * bytes are atomic and will write all or nothing. This means small cmd writes
+ * that block can be just re-tried without needing to handle partial writes. */
+typedef struct rs_bufout {
+    void *out;
+    rs_send_t *send;
+    int len;
+    rs_byte_t buf[RS_BUFOUT_LEN];
+} rs_bufout_t;
+void rs_bufout_init(rs_bufout_t *bufout, void *out, rs_send_t *send);
+int rs_bufout_send(rs_bufout_t *bufout, int len, const void *buf);
+
+/* Create a mksig job using generator for creating the delta output. */
+rs_job_t *rs_job_mksig(void *gen, rs_genmark_t *mark_cb,
+                       rs_gendata_t *block_cb);
+
+/* Create a delta job using generator for creating the delta output. */
+rs_job_t *rs_job_delta(rs_signature_t *sig, void *gen, rs_genmark_t *mark_cb,
+                       rs_gendata_t *match_cb, rs_gendata_t *miss_cb);
+
+/* Create a delta job using generator for creating the delta output. */
+rs_job_t *rs_job_patch(void *gen, rs_genmark_t *mark_cb,
+                       rs_gendata_t *match_cb, rs_gendata_t *miss_cb);
+
+/* A rs_send_t function that can drive a job by just sending data to it. */
+int rs_job_send(rs_job_t *job, int len, const void *buf);
+
+#endif                          /* _DELTAGEN_H_ */

--- a/src/emit.c
+++ b/src/emit.c
@@ -23,34 +23,35 @@
  * encoding output routines.
  *
  * \todo Pluggable encoding formats: gdiff-style, rsync 24, ed (text), Delta
- * HTTP. */
+ * HTTP.
+ *
+ * \todo Figure out how to update stats with new callback API. */
 
 #include "config.h"
 #include <assert.h>
 #include <stdlib.h>
 #include "librsync.h"
 #include "emit.h"
-#include "job.h"
 #include "netint.h"
 #include "command.h"
 #include "prototab.h"
 #include "trace.h"
 
 /** Write the magic for the start of a delta. */
-void rs_emit_delta_header(rs_job_t *job)
+int rs_put_delta_header(rs_byte_t *buf)
 {
     rs_trace("emit DELTA magic");
-    rs_squirt_n4(job, RS_DELTA_MAGIC);
+    return rs_put_netint(RS_DELTA_MAGIC, 4, buf);
 }
 
 /** Write a LITERAL command. */
-void rs_emit_literal_cmd(rs_job_t *job, int len)
+int rs_put_literal_cmd(int len, rs_byte_t *buf)
 {
     int cmd;
     int param_len = len <= 64 ? 0 : rs_int_len(len);
 
     if (param_len == 0) {
-        cmd = len;
+        cmd = (int)len;
         rs_trace("emit LITERAL_%d, cmd_byte=%#04x", len, cmd);
     } else if (param_len == 1) {
         cmd = RS_OP_LITERAL_N1;
@@ -63,36 +64,34 @@ void rs_emit_literal_cmd(rs_job_t *job, int len)
         cmd = RS_OP_LITERAL_N4;
         rs_trace("emit LITERAL_N4(len=%d), cmd_byte=%#04x", len, cmd);
     }
-
-    rs_squirt_byte(job, (rs_byte_t)cmd);
+    *buf++ = (rs_byte_t)cmd;
     if (param_len)
-        rs_squirt_netint(job, len, param_len);
-
-    job->stats.lit_cmds++;
-    job->stats.lit_bytes += len;
-    job->stats.lit_cmdbytes += 1 + param_len;
+        rs_put_netint(len, param_len, buf);
+    /* job->stats.lit_cmds++; */
+    /* job->stats.lit_bytes += len; */
+    /* job->stats.lit_cmdbytes += cmd_len; */
+    return 1 + param_len;
 }
 
 /** Write a COPY command for given offset and length.
  *
  * There is a choice of variable-length encodings, depending on the size of
  * representation for the parameters. */
-void rs_emit_copy_cmd(rs_job_t *job, rs_long_t where, rs_long_t len)
+int rs_put_copy_cmd(rs_long_t pos, rs_long_t len, rs_byte_t *buf)
 {
     int cmd;
-    rs_stats_t *stats = &job->stats;
-    const int where_bytes = rs_int_len(where);
+    const int pos_bytes = rs_int_len(pos);
     const int len_bytes = rs_int_len(len);
 
     /* Commands ascend (1,1), (1,2), ... (8, 8) */
-    if (where_bytes == 8)
+    if (pos_bytes == 8)
         cmd = RS_OP_COPY_N8_N1;
-    else if (where_bytes == 4)
+    else if (pos_bytes == 4)
         cmd = RS_OP_COPY_N4_N1;
-    else if (where_bytes == 2)
+    else if (pos_bytes == 2)
         cmd = RS_OP_COPY_N2_N1;
     else {
-        assert(where_bytes == 1);
+        assert(pos_bytes == 1);
         cmd = RS_OP_COPY_N1_N1;
     }
     if (len_bytes == 1) ;
@@ -104,23 +103,23 @@ void rs_emit_copy_cmd(rs_job_t *job, rs_long_t where, rs_long_t len)
         assert(len_bytes == 8);
         cmd += 3;
     }
-
-    rs_trace("emit COPY_N%d_N%d(where=" FMT_LONG ", len=" FMT_LONG
-             "), cmd_byte=%#04x", where_bytes, len_bytes, where, len, cmd);
-    rs_squirt_byte(job, (rs_byte_t)cmd);
-    rs_squirt_netint(job, where, where_bytes);
-    rs_squirt_netint(job, len, len_bytes);
-
-    stats->copy_cmds++;
-    stats->copy_bytes += len;
-    stats->copy_cmdbytes += 1 + where_bytes + len_bytes;
+    rs_trace("emit COPY_N%d_N%d(pos=" FMT_LONG ", len=" FMT_LONG
+             "), cmd_byte=%#04x", pos_bytes, len_bytes, pos, len, cmd);
+    *buf++ = (rs_byte_t)cmd;
+    buf += rs_put_netint(pos, pos_bytes, buf);
+    buf += rs_put_netint(len, len_bytes, buf);
+    /* job->stats.copy_cmds++; */
+    /* job->stats.copy_bytes += len; */
+    /* job->stats.copy_cmdbytes += cmd_len; */
+    return 1 + pos_bytes + len_bytes;
 }
 
 /** Write an END command. */
-void rs_emit_end_cmd(rs_job_t *job)
+int rs_put_end_cmd(rs_byte_t *buf)
 {
     int cmd = RS_OP_END;
 
     rs_trace("emit END, cmd_byte=%#04x", cmd);
-    rs_squirt_byte(job, (rs_byte_t)cmd);
+    *buf = (rs_byte_t)cmd;
+    return 1;
 }

--- a/src/emit.h
+++ b/src/emit.h
@@ -20,9 +20,9 @@
  */
 
 /** \file emit.h
- * How to emit commands to the client. */
+ * Write commands into a buffer. */
 
-void rs_emit_delta_header(rs_job_t *);
-void rs_emit_literal_cmd(rs_job_t *, int len);
-void rs_emit_end_cmd(rs_job_t *);
-void rs_emit_copy_cmd(rs_job_t *job, rs_long_t where, rs_long_t len);
+int rs_put_delta_header(rs_byte_t *buf);
+int rs_put_literal_cmd(int len, rs_byte_t *buf);
+int rs_put_copy_cmd(rs_long_t pos, rs_long_t len, rs_byte_t *buf);
+int rs_put_end_cmd(rs_byte_t *buf);

--- a/src/job.h
+++ b/src/job.h
@@ -21,6 +21,7 @@
 
 #include "mdfour.h"
 #include "checksum.h"
+#include "deltagen.h"
 
 /** The contents of this structure are private. */
 struct rs_job {
@@ -33,6 +34,12 @@ struct rs_job {
 
     /** Callback for each processing step. */
     rs_result (*statefn)(rs_job_t *);
+
+    /** Callbacks for generating delta output using stream. */
+    void *gen;
+    rs_genmark_t *mark_cb;
+    rs_gendata_t *match_cb;
+    rs_gendata_t *miss_cb;
 
     /** Final result of processing job. Used by rs_job_s_failed(). */
     rs_result final_result;
@@ -88,8 +95,12 @@ struct rs_job {
      * from the input. */
     size_t copy_len;
 
-    /** Copy from the basis position. */
-    rs_long_t basis_pos, basis_len;
+    rs_long_t basis_pos;        /**< Current match position found. */
+    int basis_len;              /**< Current match length found. */
+    rs_long_t input_pos;        /**< The input position flushed upto. */
+    rs_long_t match_pos;        /**< Match position to flush. */
+    int match_len;              /**< Match length to flush. */
+    int miss_len;               /**< Miss length to flush. */
 
     /** Callback used to copy data from the basis into the output. */
     rs_copy_cb *copy_cb;

--- a/src/netint.c
+++ b/src/netint.c
@@ -47,6 +47,17 @@
 
 #define RS_MAX_INT_BYTES 8
 
+int rs_put_netint(rs_long_t val, int len, rs_byte_t *buf)
+{
+    assert(len <= RS_MAX_INT_BYTES);
+    /* Fill buf with a bigendian representation of the number. */
+    for (int i = len - 1; i >= 0; i--) {
+        buf[i] = (rs_byte_t)val;       /* truncated */
+        val >>= 8;
+    }
+    return len;
+}
+
 /** Write a single byte to a stream output. */
 rs_result rs_squirt_byte(rs_job_t *job, rs_byte_t val)
 {
@@ -64,15 +75,8 @@ rs_result rs_squirt_byte(rs_job_t *job, rs_byte_t val)
 rs_result rs_squirt_netint(rs_job_t *job, rs_long_t val, int len)
 {
     rs_byte_t buf[RS_MAX_INT_BYTES];
-    int i;
 
-    assert(len <= RS_MAX_INT_BYTES);
-    /* Fill the output buffer with a bigendian representation of the number. */
-    for (i = len - 1; i >= 0; i--) {
-        buf[i] = (rs_byte_t)val;       /* truncated */
-        val >>= 8;
-    }
-    rs_tube_write(job, buf, len);
+    rs_tube_write(job, buf, rs_put_netint(val, len, buf));
     return RS_DONE;
 }
 

--- a/src/netint.h
+++ b/src/netint.h
@@ -20,6 +20,8 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
+int rs_put_netint(rs_long_t val, int len, rs_byte_t *buf);
+
 rs_result rs_squirt_byte(rs_job_t *job, rs_byte_t val);
 rs_result rs_squirt_netint(rs_job_t *job, rs_long_t val, int len);
 rs_result rs_squirt_n4(rs_job_t *job, int val);

--- a/src/patch.c
+++ b/src/patch.c
@@ -144,7 +144,7 @@ static rs_result rs_patch_s_copy(rs_job_t *job)
     stats->copy_bytes += len;
     stats->copy_cmdbytes += 1 + job->cmd->len_1 + job->cmd->len_2;
     job->basis_pos = pos;
-    job->basis_len = len;
+    job->basis_len = (int)len;
     job->statefn = rs_patch_s_copying;
     return RS_RUNNING;
 }


### PR DESCRIPTION
This is in a pretty rough initial state, but it does work and passes all
tests. It's far from optimized, and only changes deltas to the new API. A
bunch of stuff is yet to be deprecated away pending other job types using this
API too.

Add deltagen.[ch] which defines and implements the delta generator callback
API. The default rs_deltagen_t generates deltas identical to the current
release. Add some rs_send_t data writers for files, buffers, and jobs. Also
includes an unused rs_bufout_t data writer that buffers output.

Change job.h to add fields needed by the delta generator API. Also change all
match/miss length fields to `int` to reflect that the lengths are constrained
to less than int-sized lengths.

Change delta.c to use an rs_deltagen_t delta generator, fixing it to correctly
flush and not rely on iterator calls to invoke rs_tube_catchup() between
state-function calls. Also make it never accumulte more than
MAX_DATA_LEN=32768 of hits as well as misses before invoking the the callback
API, since we now keep and pass match data to the API as well.

Change emit.[ch] to emit cmds into buffers, not directly to the tube. We need
this so cmds can be sent to different delta-generator backends, not just to
the job stream via the tube.

In netint.[ch] add rs_put_netint() to write netints to a buffer, not directly
to the tube. This is now used by emit.c.