### PR TITLE
Add gnuwin popt for travis windows tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,18 @@ addons:
       - popt
     update: true
 
+cache:
+    directories:
+        - $HOME/AppData/Local/Temp/chocolatey
+
 script:
   - cmake --build . --target check
 
 matrix:
   include:
     - os: windows
+      before_install:
+        - choco install gnuwin
 
     - os: osx
       compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
   include:
     - os: windows
       before_install:
-        - choco install gnuwin
+        - choco install -y gnuwin
 
     - os: osx
       compiler: clang


### PR DESCRIPTION
It appears the choco gnuwin should include popt, which should result in a working rdiff for testing on windows.