### PR TITLE
Fix heap corruption from too small kbloom

### DIFF
--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -52,7 +52,7 @@ hashtable_t *_hashtable_new(int size)
     t->count = 0;
     t->tmask = size2 - 1;
 #ifndef HASHTABLE_NBLOOM
-    if (!(t->kbloom = calloc(size2 / 8, sizeof(unsigned char)))) {
+    if (!(t->kbloom = calloc((size2 + 7) / 8, sizeof(unsigned char)))) {
         _hashtable_free(t);
         return NULL;
     }


### PR DESCRIPTION
kbloom is a bitmask with 'size2' bits, where 'size2' is the next power of 2 of 'size'. Thus, if 'size' is smaller than 4, 'size2' is smaller than 8, so that size2 / 8 == 0 and calloc allocates 0 bytes. This causes heap corruption when kbloom is subsequently written to. See discussion on https://groups.google.com/g/librsync/c/vmqzQS1QjIw.