### PR TITLE
cmake: fix warning for later CMake versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,7 +180,7 @@ if (ZLIB_FOUND)
 endif (ZLIB_FOUND)
 
 # Find libb2
-find_package(libb2)
+find_package(LIBB2)
 if (LIBB2_FOUND)
   message (STATUS "LIBB2_INCLUDE_DIRS  = ${LIBB2_INCLUDE_DIRS}")
   message (STATUS "LIBB2_LIBRARIES = ${LIBB2_LIBRARIES}")

--- a/cmake/FindLIBB2.cmake
+++ b/cmake/FindLIBB2.cmake
@@ -12,8 +12,8 @@
 find_path (LIBB2_INCLUDE_DIR blake2.h)
 find_library (LIBB2_LIBRARY_RELEASE b2)
 
-INCLUDE(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS (LIBB2 DEFAULT_MSG LIBB2_LIBRARY_RELEASE LIBB2_INCLUDE_DIR)
+include (FindPackageHandleStandardArgs)
+find_package_handle_standard_args (LIBB2 DEFAULT_MSG LIBB2_LIBRARY_RELEASE LIBB2_INCLUDE_DIR)
 
 # Set output vars from auto-detected/cached vars.
 if (LIBB2_FOUND)


### PR DESCRIPTION
When building this project with CMake (version 3.20.5), I got the following error message:

```
-- Found ZLIB: /usr/lib64/libz.so (found version "1.2.11") 
-- ZLIB_INCLUDE_DIRS  = /usr/include
-- ZLIB_LIBRARIES = /usr/lib64/libz.so
CMake Warning (dev) at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:438 (message):
  The package name passed to `find_package_handle_standard_args` (LIBB2) does
  not match the name of the calling package (libb2).  This can lead to
  problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  cmake/Findlibb2.cmake:16 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  CMakeLists.txt:183 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Found LIBB2: /usr/lib64/libb2.so  
-- LIBB2_INCLUDE_DIRS  = /usr/include
-- LIBB2_LIBRARIES = /usr/lib64/libb2.so
```

To fix it, I've just followed the error message instruction and renamed the `cmake/Findlibb2.cmake` to `cmake/FindLIBB2.cmake`. (Plus, I've converted the CMake commands to lowercase to match with the rest of the project.)