### PR TITLE
Fix bash test scripts to work on Windows.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Data files used for tests.
+*.data binary
+*.in binary
+*.sig binary
+*.delta binary
+*.expect binary

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,20 +279,37 @@ target_compile_options(sumset_test PRIVATE -DLIBRSYNC_STATIC_DEFINE)
 target_link_libraries(sumset_test ${blake2_LIBS})
 add_test(NAME sumset_test COMMAND sumset_test)
 
+# On Windows we need to explicitly execute bash for scripts.
+if (WIN32)
+    set(WIN_BASH bash)
+endif (WIN32)
+
 # Disable rdiff specific tests
 if (BUILD_RDIFF)
     add_test(NAME rdiff_bad_option
-             COMMAND rdiff_bad_option.sh ${CMAKE_CURRENT_BINARY_DIR}
-             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-
-    add_test(NAME Help COMMAND help.test ${CMAKE_CURRENT_BINARY_DIR} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-
-    add_test(NAME Mutate COMMAND mutate.test ${CMAKE_CURRENT_BINARY_DIR} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-    add_test(NAME Signature COMMAND signature.test ${CMAKE_CURRENT_BINARY_DIR} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-    add_test(NAME Sources COMMAND sources.test ${CMAKE_CURRENT_BINARY_DIR} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-    add_test(NAME Triple COMMAND triple.test ${CMAKE_CURRENT_BINARY_DIR} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-    add_test(NAME Delta COMMAND delta.test ${CMAKE_CURRENT_BINARY_DIR} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-    add_test(NAME Changes COMMAND changes.test ${CMAKE_CURRENT_BINARY_DIR} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+        COMMAND ${WIN_BASH} rdiff_bad_option.sh $<TARGET_FILE:rdiff>
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+    add_test(NAME Help
+        COMMAND ${WIN_BASH} help.test $<TARGET_FILE:rdiff>
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+    add_test(NAME Mutate
+        COMMAND ${WIN_BASH} mutate.test $<TARGET_FILE:rdiff>
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+    add_test(NAME Signature
+        COMMAND ${WIN_BASH} signature.test $<TARGET_FILE:rdiff>
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+    add_test(NAME Sources
+        COMMAND ${WIN_BASH} sources.test $<TARGET_FILE:rdiff>
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+    add_test(NAME Triple
+        COMMAND ${WIN_BASH} triple.test $<TARGET_FILE:rdiff>
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+    add_test(NAME Delta
+        COMMAND ${WIN_BASH} delta.test $<TARGET_FILE:rdiff>
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+    add_test(NAME Changes
+        COMMAND ${WIN_BASH} changes.test $<TARGET_FILE:rdiff>
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
 endif (BUILD_RDIFF)
 
 

--- a/cmake/FindPOPT.cmake
+++ b/cmake/FindPOPT.cmake
@@ -27,7 +27,6 @@
 # - Check for the presence of POPT
 #
 # The following vars can be set to change behaviour;
-#  POPT_ROOT_DIR - path hint for finding popt.
 #  POPT_INCLUDE_DIR - cached override for POPT_INCLUDE_DIRS.
 #  POPT_LIBRARY_RELEASE - cached override for POPT_LIBRARIES.
 #
@@ -49,12 +48,8 @@ endif (PKG_CONFIG_FOUND)
 
 # Fallback to searching for path and library if PkgConfig didn't work.
 if (NOT POPT_FOUND)
-  find_path (POPT_INCLUDE_DIR popt.h
-    HINTS ${POPT_ROOT_DIR} ${CMAKE_INSTALL_PREFIX} $ENV{programfiles}\\GnuWin32 $ENV{programfiles32}\\GnuWin32
-    PATH_SUFFIXES include)
-  find_library (POPT_LIBRARY_RELEASE popt
-    HINTS ${POPT_ROOT_DIR} ${CMAKE_INSTALL_PREFIX} $ENV{programfiles}\\GnuWin32 $ENV{programfiles32}\\GnuWin32
-    PATH_SUFFIXES lib)
+  find_path (POPT_INCLUDE_DIR popt.h)
+  find_library (POPT_LIBRARY_RELEASE popt)
 endif (NOT POPT_FOUND)
 
 # Check library and paths and set POPT_FOUND appropriately.

--- a/tests/delta.test
+++ b/tests/delta.test
@@ -33,7 +33,7 @@ for delta in $inputdir/*.delta
 do
     for inbuf in $bufsizes
     do
-        cmd="$bindir/rdiff -I$inbuf -f patch /dev/null $delta $new"
+        cmd="${RDIFF} -I$inbuf -f patch /dev/null $delta $new"
         run_test $cmd
         expect=$inputdir/`basename $delta .delta`.expect
 	check_compare $expect $new
@@ -50,7 +50,7 @@ ret=0
 # Change $new and rerun last test to check it won't be reverted
 echo "$output_expect" > $expect
 echo "$output_expect" > $new
-cmd="$bindir/rdiff patch /dev/null $delta $new"
+cmd="${RDIFF} patch /dev/null $delta $new"
 echo "    $cmd" >&2
 output="`$cmd 2>&1`" || ret=$?
 [ "$ret" -eq "$RS_IO_ERROR" ] ||

--- a/tests/help.test
+++ b/tests/help.test
@@ -23,8 +23,8 @@
 srcdir='.'
 . $srcdir/testcommon.sh
 
-run_test $bindir/rdiff --help
-run_test $bindir/rdiff --version
+run_test ${RDIFF} --help
+run_test ${RDIFF} --version
 
-run_test $bindir/rdiff --help | grep ' --statistics'
-run_test $bindir/rdiff --version | grep 'Copyright'
+run_test ${RDIFF} --help | grep ' --statistics'
+run_test ${RDIFF} --version | grep 'Copyright'

--- a/tests/largefile.test
+++ b/tests/largefile.test
@@ -27,7 +27,7 @@
 srcdir='.'
 . $srcdir/testcommon.sh
 
-# Note $1 is used to specify "BINDIR" by cmake tests, so we use
+# Note $1 is used to specify "RDIFF" by cmake tests, so we use
 # arguments after that.
 
 # Allow the number of blocks to be specified in $2 in the form '64K'.
@@ -57,8 +57,8 @@ if [ ! -f "$old" ]; then
    dd bs=$blocks count=256 skip=640 if="$old" >>"$new"
 fi
 
-run_test time $bindir/rdiff $debug -f -s -b $blocksize -S 8 signature $old $sig
-run_test time $bindir/rdiff $debug -f -s delta $sig $new $delta
-run_test time $bindir/rdiff $debug -f -s patch $old $delta $out
+run_test time ${RDIFF} $debug -f -s -b $blocksize -S 8 signature $old $sig
+run_test time ${RDIFF} $debug -f -s delta $sig $new $delta
+run_test time ${RDIFF} $debug -f -s patch $old $delta $out
 check_compare $new $out "large files"
 true

--- a/tests/mutate.test
+++ b/tests/mutate.test
@@ -48,9 +48,9 @@ do
 
     for hashopt in '' -Hmd4 -Hblake2
     do
-	run_test $bindir/rdiff -f $debug $hashopt signature $old $sig
-	run_test $bindir/rdiff -f $debug delta $sig $new $delta
-	run_test $bindir/rdiff -f $debug patch $old $delta $out
+	run_test ${RDIFF} -f $debug $hashopt signature $old $sig
+	run_test ${RDIFF} -f $debug delta $sig $new $delta
+	run_test ${RDIFF} -f $debug patch $old $delta $out
 
 	check_compare "$new" "$out" "mutate $i $old $new"
     done

--- a/tests/performance.test
+++ b/tests/performance.test
@@ -27,7 +27,7 @@
 srcdir='.'
 . $srcdir/testcommon.sh
 
-# Note $1 is used to specify "BINDIR" by cmake tests, so we use
+# Note $1 is used to specify "RDIFF" by cmake tests, so we use
 # arguments after that.
 
 # Allow a data directory to be specified in $2 to use persistent
@@ -39,7 +39,7 @@ echo "DATADIR $datadir"
 run_test () {
   echo $1 blocks of 1K size.
   echo ========================
-  $srcdir/largefile.test $bindir $1 $2
+  $srcdir/largefile.test $RDIFF $1 $2
   echo
 }
 

--- a/tests/rdiff_bad_option.sh
+++ b/tests/rdiff_bad_option.sh
@@ -1,4 +1,4 @@
-#! /bin/sh -ex
+#! /bin/sh -e
 
 # librsync -- the library for network deltas
 
@@ -21,8 +21,11 @@
 
 # Bad command-line options return an error and print a message.
 
-errout=`mktemp -t rdiff_bad_option_test_XXXXXXX`
-trap "rm $errout" EXIT
-! $1/rdiff --imaginary-option 2>"$errout"
+srcdir='.'
+. $srcdir/testcommon.sh
+
+errout=$tmpdir/rdiff.err
+set -x
+! ${RDIFF} --imaginary-option 2>"$errout"
 cat "$errout"
 grep 'unknown option: --imaginary-option' "$errout"

--- a/tests/signature.test
+++ b/tests/signature.test
@@ -34,7 +34,7 @@ for rollfunc in rollsum rabinkarp; do
       for input in "$srcdir/signature.input"/*.in; do
         for inbuf in $bufsizes; do
           expect=`echo $input | sed -e "s/.in\$/-R${rollfunc}-H${hashfunc}-S${stronglen}.sig/"`
-          run_test $bindir/rdiff -R$rollfunc -H$hashfunc -S$stronglen -I$inbuf -f signature "$input" "$new"
+          run_test ${RDIFF} -R$rollfunc -H$hashfunc -S$stronglen -I$inbuf -f signature "$input" "$new"
           check_compare "$expect" "$new"
 	done
       done

--- a/tests/testcommon.sh
+++ b/tests/testcommon.sh
@@ -6,25 +6,19 @@
 # modify it under the terms of the GNU Lesser General Public License
 # as published by the Free Software Foundation; either version 2.1 of
 # the License, or (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful, but
 # WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # Lesser General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU Lesser General Public
 # License along with this program; if not, write to the Free Software
 # Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
-
-# For CMake tests
-bindir=$1
-if [ -z "$bindir" ]
-then
-   # Fallback to automake tests
-   bindir='..'
-fi
-echo "BINDIR $bindir"
+# For CMake tests we pass in the full path to rdiff as $1.
+RDIFF=${1:-../rdiff}
+echo "RDIFF $RDIFF"
 
 testinputdir=$srcdir/$test_base.input
 tmpdir=`mktemp -d -t librsynctest_XXXXXXXX`
@@ -54,12 +48,12 @@ delta_instr="
 bufsizes='0 1 2 3 7 15 100 10000 200000'
 
 run_test () {
-    if :|| test -n "$VERBOSE" 
+    if :|| test -n "$VERBOSE"
     then
 	echo "    $@" >&2
     fi
 
-    "$@" || fail_test "$?" "$@" 
+    "$@" || fail_test "$?" "$@"
 }
 
 fail_test () {
@@ -86,11 +80,11 @@ triple_test () {
     old="$2"
     new="$3"
     hashopt="$4"
-    
-    run_test $bindir/rdiff $debug $hashopt -f -I$buf -O$buf $stats signature --block-size=$block_len \
+
+    run_test ${RDIFF} $debug $hashopt -f -I$buf -O$buf $stats signature --block-size=$block_len \
              $old $tmpdir/sig
-    run_test $bindir/rdiff $debug $hashopt -f -I$buf -O$buf $stats delta $tmpdir/sig $new $tmpdir/delta
-    run_test $bindir/rdiff $debug $hashopt -f -I$buf -O$buf $stats patch $old $tmpdir/delta $tmpdir/new
+    run_test ${RDIFF} $debug $hashopt -f -I$buf -O$buf $stats delta $tmpdir/sig $new $tmpdir/delta
+    run_test ${RDIFF} $debug $hashopt -f -I$buf -O$buf $stats patch $old $tmpdir/delta $tmpdir/new
     check_compare $new $tmpdir/new "triple -f -I$buf -O$buf $old $new"
 }
 

--- a/tests/triple.test
+++ b/tests/triple.test
@@ -31,18 +31,18 @@ do
         do
             for hashopt in -Hmd4 -Hblake2
             do
-                run_test $bindir/rdiff $debug $hashopt -f -I$buf -O$buf signature $old $tmpdir/sig
-                run_test $bindir/rdiff $debug $hashopt -f -I$buf -O$buf delta $tmpdir/sig $new $tmpdir/delta
-                run_test $bindir/rdiff $debug $hashopt -f -I$buf -O$buf patch $old $tmpdir/delta $tmpdir/new
+                run_test ${RDIFF} $debug $hashopt -f -I$buf -O$buf signature $old $tmpdir/sig
+                run_test ${RDIFF} $debug $hashopt -f -I$buf -O$buf delta $tmpdir/sig $new $tmpdir/delta
+                run_test ${RDIFF} $debug $hashopt -f -I$buf -O$buf patch $old $tmpdir/delta $tmpdir/new
 
                 check_compare $new $tmpdir/new "triple -I$buf -O$buf $old $new"
 
                 # Run tests again and check if reading and writing to pipes works
                 :> $tmpdir/new
-                cat $old | run_test $bindir/rdiff $debug $hashopt -I$buf -O$buf signature > $tmpdir/sig
+                cat $old | run_test ${RDIFF} $debug $hashopt -I$buf -O$buf signature > $tmpdir/sig
                 # this test pipes signature instead of $new so that signature memory preallocation is tested
-                cat $tmpdir/sig | run_test $bindir/rdiff $debug $hashopt -I$buf -O$buf delta - $new > $tmpdir/delta
-                cat $tmpdir/delta | run_test $bindir/rdiff $debug $hashopt -I$buf -O$buf patch $old > $tmpdir/new
+                cat $tmpdir/sig | run_test ${RDIFF} $debug $hashopt -I$buf -O$buf delta - $new > $tmpdir/delta
+                cat $tmpdir/delta | run_test ${RDIFF} $debug $hashopt -I$buf -O$buf patch $old > $tmpdir/new
 
                 check_compare $new $tmpdir/new "triple -I$buf -O$buf $old $new"
             done


### PR DESCRIPTION
This makes all tests pass on Windows when libpopt is installed so rdiff is built and tested. This includes;

* Tidy and simplify cmake/FindPOPT.cmake.
* Fix bash test scripts invoked by cmake to work on Windows.
* Add .gitattributes to ensure test data is binary

Note libpopt is now available on windows in the vcpkg package repository. It can used to compile and test rdiff on Windows like this;

```sh
$ vcpkg --triplet x64-windows install libpopt
$ cmake -B Release -DCMAKE_BUILD_TYPE=Release \
 -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
$ cmake --build Release --config Release --target check
```