### PR TITLE
Tidy the cmake config and add better build configuration support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,10 @@ if (NOT CMAKE_SYSTEM_NAME)
 	message(FATAL_ERROR "No target OS set")
 endif()
 
+# Set CMAKE_BUILD_TYPE if unset.
+include(BuildType)
+message (STATUS "CMAKE_BUILD_TYPE = ${CMAKE_BUILD_TYPE}")
+
 option(BUILD_SHARED_LIBS "Build librsync as a shared library." ON)
 
 # Option ENABLE_TRACE defaults to ON for Debug builds.

--- a/cmake/BuildType.cmake
+++ b/cmake/BuildType.cmake
@@ -1,0 +1,23 @@
+# Manage CMAKE_BUILD_TYPE.
+#
+# This sets the default build type to "Release or "Debug" for a git clone, and
+# sets up the possible values for the cmake-gui. It understands multi-config
+# generators and respects values set on the cmdline. It comes from;
+#
+# https://blog.kitware.com/cmake-and-the-default-build-type/
+
+# Set the default build type for when none was specified.
+set(DEFAULT_BUILD_TYPE "Release")
+if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
+  set(DEFAULT_BUILD_TYPE "Debug")
+endif()
+
+# If CMAKE_BUILD_TYPE is not set and not using a multi-config generator, set
+# it to the default and setup the possible values for the cmake-gui.
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to '${DEFAULT_BUILD_TYPE}' as none was specified.")
+  set(CMAKE_BUILD_TYPE "${DEFAULT_BUILD_TYPE}" CACHE
+    STRING "Choose the type of build." FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE
+    PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()


### PR DESCRIPTION
This is an idea taken from the following post;
    
https://blog.kitware.com/cmake-and-the-default-build-type/
    
It sets the default build type to Debug for git clone, otherwise the default is Release. It also sets possible values for the cmake-gui or ccmake. It works with multi-config generators and respects values set on the cmdline.
