### PR TITLE
Add github action and make targets for clang-tidy and iwyu.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,2 @@
+# clang-analyzer-valist.Uninitialized has a bug https://bugs.llvm.org/show_bug.cgi?id=41311.
+Checks: "-clang-analyzer-valist.Uninitialized"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
       # Unfortunately available Marketplace Actions for this are in a mess, so we do it manually.
       run: |
         sudo apt-get update -y
-        sudo apt-get install -y libpopt-dev libb2-dev clang-tools iwyu
+        sudo apt-get install -y libpopt-dev libb2-dev clang-tidy iwyu
 
     - name: Configure CMake
       run: cmake .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install Dependencies
+      # Unfortunately available Marketplace Actions for this are in a mess, so we do it manually.
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y libpopt-dev libb2-dev clang-tools iwyu
+
+    - name: Configure CMake
+      run: cmake .
+
+    - name: clang-tidy
+      run: cmake --build . --target clang-tidy
+
+    - name: iwyu
+      run: cmake --build . --target iwyu

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,9 +11,11 @@ jobs:
 
     - name: Install Dependencies
       # Unfortunately available Marketplace Actions for this are in a mess, so we do it manually.
+      # Also iwyu is missing a dependency on libclang-common-0-dev, See;
+      # https://bugs.launchpad.net/ubuntu/+source/iwyu/+bug/1769334
       run: |
         sudo apt-get update -y
-        sudo apt-get install -y libpopt-dev libb2-dev clang-tidy libclang-dev llvm-dev iwyu
+        sudo apt-get install -y libpopt-dev libb2-dev clang-tidy libclang-common-9-dev iwyu
 
     - name: Configure CMake
       run: cmake .
@@ -23,5 +25,4 @@ jobs:
 
     - name: iwyu
       run: |
-        iwyu  -E -xc - -v </dev/null
         cmake --build . --target iwyu

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,5 +24,4 @@ jobs:
       run: cmake --build . --target clang-tidy
 
     - name: iwyu
-      run: |
-        cmake --build . --target iwyu
+      run: cmake --build . --target iwyu

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
       # Unfortunately available Marketplace Actions for this are in a mess, so we do it manually.
       run: |
         sudo apt-get update -y
-        sudo apt-get install -y libpopt-dev libb2-dev clang-tidy libclang-dev iwyu
+        sudo apt-get install -y libpopt-dev libb2-dev clang-tidy libclang-dev llvm-dev iwyu
 
     - name: Configure CMake
       run: cmake .
@@ -22,4 +22,6 @@ jobs:
       run: cmake --build . --target clang-tidy
 
     - name: iwyu
-      run: cmake --build . --target iwyu
+      run: |
+        iwyu  -E -xc - -v </dev/null
+        cmake --build . --target iwyu

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
       # Unfortunately available Marketplace Actions for this are in a mess, so we do it manually.
       run: |
         sudo apt-get update -y
-        sudo apt-get install -y libpopt-dev libb2-dev clang-tidy iwyu
+        sudo apt-get install -y libpopt-dev libb2-dev clang-tidy libclang-dev iwyu
 
     - name: Configure CMake
       run: cmake .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,10 +259,18 @@ add_custom_target(clang-tidy
     VERBATIM
 )
 
-# clang-tidy target to check code for errors.
+# iwyu target to check includes for correctness.
 add_custom_target(iwyu
     COMMENT "Check #includes for correctness using iwyu_tool."
     COMMAND iwyu_tool -p ${CMAKE_CURRENT_BINARY_DIR}
+    VERBATIM
+)
+
+# iwyu-fix target to fix includes for correctness.
+# Note fileutil.c gets mangled by this and is excluded.
+add_custom_target(iwyu-fix
+    COMMENT "Fix #includes for correctness using iwyu_tool and fix_include."
+    COMMAND iwyu_tool -p ${CMAKE_CURRENT_BINARY_DIR} | fix_include --noblank_lines --ignore_re=fileutil.c
     VERBATIM
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ set(LIBRSYNC_VERSION
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-# Turn on generating compile_commands.json for clang-tidy, clang-sa, and iwyu.
+# Turn on generating compile_commands.json for clang-tidy and iwyu.
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 if (NOT CMAKE_SYSTEM_PROCESSOR)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,9 @@ set(LIBRSYNC_VERSION
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
+# Turn on generating compile_commands.json for clang-tidy, clang-sa, and iwyu.
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 if (NOT CMAKE_SYSTEM_PROCESSOR)
 	message(FATAL_ERROR "No target CPU architecture set")
 endif()
@@ -246,6 +249,13 @@ add_custom_target(tidyc
     COMMENT "Reformatting all code and comments to preferred coding style."
     # Recomended format, reformat linebreaks, reformat comments, 80 columns.
     COMMAND tidyc -R -C -l80 -T FILE -T Rollsum -T rs_result ${tidy_SRCS}
+    VERBATIM
+)
+
+# clang-tidy target to check code for errors.
+add_custom_target(clang-tidy
+    COMMENT "Check code for errors using clang-tidy."
+    COMMAND run-clang-tidy -p ${CMAKE_CURRENT_BINARY_DIR}
     VERBATIM
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,6 +259,13 @@ add_custom_target(clang-tidy
     VERBATIM
 )
 
+# clang-tidy target to check code for errors.
+add_custom_target(iwyu
+    COMMENT "Check #includes for correctness using iwyu_tool."
+    COMMAND iwyu_tool -p ${CMAKE_CURRENT_BINARY_DIR}
+    VERBATIM
+)
+
 # Testing
 
 add_executable(isprefix_test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,13 +3,144 @@
 Instructions and conventions for people wanting to work on librsync.  Please
 consider these guidelines even if you're doing your own fork.
 
-## Code Style
+## Requirements
+
+There are a bunch of tools and libraries that are useful for development or
+that librsync depends on. In addition to the standard cmake/gcc/make/etc C
+development tools, the following packages are recommended;
+
+* libpopt-dev - the cmdline argument parsing library used by rdiff. If this is
+  not available rdiff cannot be compiled, and only the librsync library will
+  be compiled.
+
+* libb2-dev - blake2 hash library librsync can use if `USE_LIBB2` is set to
+  `ON` in cmake. If this is not avalable librsync will use its included copy
+  of blake2 (which may be older... or newer).
+
+* doxygen - documentation generator used to generate html documentation. If
+  installed `make doc` can be run to generate all the docs.
+
+* graphviz - graph generator used by doxygen for generating diagrams. If not
+  installed doxygen will not generate any diagrams.
+
+* indent - code reformatter for tidying code. If installed all the code can be
+  tidied with `make tidy`.
+
+* [tidyc](https://github.com/dbaarda/tidyc) - extension wrapper for indent
+  that includes better formatting of doxygen comments. If installed code and
+  comments can be tidied with `make tidyc`.
+
+* clang-tidy - code lint checker for potential problems. If installed the code
+  can be checked with `make clang-tidy`.
+
+* iwyu - `#include` checker and fixer. If installed includes can be checked
+  with `make iwyu`, and automatically fixed with `make iwyu-fix`. Note on some
+  platforms this package is [missing a
+  dependency](https://bugs.launchpad.net/ubuntu/+source/iwyu/+bug/1769334) and
+  also needs `libclang-common-9-dev` to be installed.
+
+These can all be installed on Debian/Ubuntu systems by running;
+
+```Shell
+$ apt-get update
+$ apt-get install libpopt-dev libb2-dev doxygen graphviz indent clang-tidy iwyu
+$ git clone https://github.com/dbaarda/tidyc.git
+$ cp tidyc/tidyc ~/bin
+```
+
+### Windows
+
+Not all the recommended packages are easily available on windows.
+[Cygwin](https://cygwin.com/) and [MSYS2](http://msys2.org/) provide a
+development environment similar to Linux. Some packages can also be found on
+[Chocolatey](https://chocolatey.org/). For native development using standard
+MSVC tools, libpopt can be found on [vcpkg](https://vcpkg.io/) and installed
+by running;
+
+```Shell
+$ vcpkg update
+$ vcpkg --triplet x64-windows install libpopt
+```
+
+For cmake to find the installed libpopt you need to add `-D
+CMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake` to the cmake
+cmdline. This configures cmake to correctly search the vcpkg install locations
+to find libraries.
+
+### MacOS
+
+MacOS is generally more similar to Linux than Windows, and several packages
+are available on homebrew. The libpopt library can be installed by running;
+
+```Shell
+$ brew update
+$ brew install popt
+```
+
+## Building
+
+The minimal instructions to fetch, configure, compile, and test everything
+using a in-place default Debug build with trace enabled using the internal
+blake2 implementation is;
+
+```Shell
+$ git clone https://github.com/librsync/librsync.git
+$ cd librsync
+$ cmake .
+$ make check
+```
+
+For cmake, `-B` can be used to select a separate build directory, and `-G` can
+select a different make system. Also the following settings can be changed
+with `-D <setting>=<value>` arguments when generating the project with cmake;
+
+* CMAKE_BUILD_TYPE=(Debug|Release|MinSizeRel|RelWithDebInfo) - the build type
+  to use, which selects compiler options. The default is `Debug`.
+
+* CMAKE_C_COMPILER=(cc|gcc|clang|...) - The compiler to use. The default is to
+  auto-detect the available compiler on the platform.
+
+* BUILD_RDIFF=(ON|OFF) - Whether to build and test the rdiff executable.
+  Defaults to ON if libpopt is available.
+
+* BUILD_SHARED_LIBS=(ON|OFF) - Whether to build dynamic libraries or use
+  static linking. Defaults to ON.
+
+* ENABLE_TRACE=(ON|OFF) - Whether to enable trace output in the library and
+  for rdiff using `-v`. Trace output can help with debugging but its a little
+  faster with ENABLE_TRACE=OFF. Defaults to ON for Debug builds, and OFF for
+  others.
+
+* USE_LIBB2=(ON|OFF) - Whether to use libb2 instead of the included blake2
+  implementation. Defaults to OFF.
+
+So for a Release build in a separate directory using Ninja, clang, static
+linking, and libb2 with trace enabled, do this instead;
+
+```Shell
+$ cmake -B build -G Ninja
+  -D CMAKE_C_COMPILER=clang \
+  -D CMAKE_BUILD_TYPE=Release \
+  -D BUILD_SHARED_LIBS=OFF \
+  -D USE_LIBB2=ON \
+  -D ENABLE_TRACE=ON
+$ cmake --build build --config Release --target check
+```
+
+You can also use ccmake or cmake-gui to interactively configure and generate
+into a separate build directory with;
+
+```Shell
+$ ccmake -B build
+```
+
+## Coding
 
 The prefered style for code is equivalent to using GNU indent with the
 following arguments;
 
 ```Shell
-$ indent -linux -nut -i4 -ppi2 -l80 -lc80 -fc1 -fca -sob
+$ indent -linux -nut -i4 -ppi2 -l80 -lc80 -fc1 -sob -T FILE -T Rollsum -T rs_result
 ```
 
 The preferred style for non-docbook comments are as follows;
@@ -56,20 +187,68 @@ follows;
                                  * With blank line delimited paragraphs.*/
 ```
 
-There is a `make tidy` target that will use GNU indent to reformat all
-code and non-docbook comments, doing some pre/post processing with sed
-to handle some corner cases indent doesn't handle well.
+There is a `make tidy` target that will use GNU indent to reformat all code
+and non-docbook comments, doing some pre/post processing with sed to handle
+some corner cases indent doesn't handle well.
 
-There is also a `make tidyc` target that will reformat all code and
-comments with https://github.com/dbaarda/tidyc. This will also
-correctly reformat all docbook comments, equivalent to running tidyc
-with the following arguments;
+There is a `make tidyc` target that will reformat all code and comments with
+[tidyc](https://github.com/dbaarda/tidyc). This will also correctly reformat
+all docbook comments, equivalent to running tidyc with the following
+arguments;
 
 ```Shell
-$ tidyc -R -C -l80
+$ tidyc -R -C -l80 -T FILE -T Rollsum -T rs_result
 ```
 
-## Pull requests
+There is `make clang-tidy` and `make iwyu` targets for checking for coding
+errors and incorrect `#include` statements. Note that the iwyu check gets
+confused by and will emit warnings about `fileutil.c` which has extra
+conditional includes necessary to find working functions on various platforms.
+Other than `fileutil.c` both checks should be clean.
+
+If iwyu finds problems, `make ifwu-fix` can be run to automatically fix them,
+followed by `make tidyc` to reformat the result to our preferred style. Note
+that this doesn't always produce an ideal result and may require manual
+intervention.
+
+Please try to update docs and tests in parallel with code changes.
+
+## Testing
+
+Using `make check` will compile and run all tests. Additional code correctness
+checks can be run with `make clang-tidy` and `make iwyu`.
+
+Note that `assert()` is used extensively within the code for verifying the
+correctness of internal operations using a roughly design-by-contract
+approach. These are only enabled for Debug builds, so testing with a Debug
+build will give a better chance of identifying problems during development.
+Once you are confident the code is correct, a Release build will turn these
+off giving faster execution.
+
+There are also GitHub Actions configured for the librsync project to
+configure, build, test, and lint everything on a variety of different
+platforms with a variety of different settings. These are run against any pull
+request or commit, and are a good way to check things are not broken for other
+platforms.
+
+Test results for builds of public github branches are at
+https://github.com/librsync/librsync/actions.
+
+## Documenting
+
+[NEWS.md](NEWS.md) contains a list of user-visible changes in the library
+between release versions. This includes changes to the way it's packaged, bug
+fixes, portability notes, changes to the API, and so on. Add and update items
+under a "Changes in X.Y.Z" heading at the top of the file. Do this as you go
+along, so that we don't need to work out what happened when it's time for a
+release.
+
+[TODO.md](TODO.md) contains a list of ideas and proposals for the future.
+Ideally entries should be formated in a way that can be just moved into
+[NEWS.md](NEWS.md) when they are done. Regularly check to see if there is
+anything that needs removing or updating.
+
+## Submitting
 
 Fixes or improvements in pull requests are welcome.  Please:
 
@@ -83,22 +262,6 @@ Fixes or improvements in pull requests are welcome.  Please:
 - [ ] Keep the code style consistent with what's already there, especially in
   keeping symbols with an `rs_` prefix.
 
-
-## NEWS
-
-[NEWS.md](NEWS.md) contains a list of user-visible changes in the library between
-releases version. This includes changes to the way it's packaged,
-bug fixes, portability notes, changes to the API, and so on.
-
-Add
-and update items under a "Changes in X.Y.Z" heading at the top of
-the file. Do this as you go along, so that we don't need to work
-out what happened when it's time for a release.
-
-## Tests
-
-Please try to update docs and tests in parallel with code changes.
-
 ## Releasing
 
 If you are making a new tarball release of librsync, follow this checklist:
@@ -106,12 +269,16 @@ If you are making a new tarball release of librsync, follow this checklist:
 * NEWS.md - make sure the top "Changes in X.Y.Z" is correct, and the date is
   correct. Make sure the changes since the last release are documented.
 
+* TODO.md - check if anything needs to be removed or updated.
+
 * `CMakeLists.txt` - version is correct.
 
 * `librsync.spec` - make sure version and URL are right.
 
 * Run `make all doc check` in a clean checkout of the release tag. Also check
-  the travis-cl check status of the last commit on github.
+  the GitHub Actions [check and lint
+  status](https://github.com/librsync/librsync/actions) of the last commit on
+  github.
 
 * Draft a new release on github, typing in the release details including an
   overview, included changes, and known issues. The overview should give an
@@ -123,6 +290,3 @@ If you are making a new tarball release of librsync, follow this checklist:
 * After creating the release, download the tar.gz version, edit the release,
   and re-upload it. This ensures that the release includes a stable tarball
   (See https://github.com/librsync/librsync/issues/146 for details).
-
-Test results for builds of public github branches are at
-https://travis-ci.org/librsync/librsync.

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,41 @@
 
 NOT RELEASED YET
 
+ * Add github action and make targets for clang-tidy and iwyu. Added
+   `clang-tidy` and `iwyu` make targets for checking code and includes, and
+   `iwyu-fix` for fixing includes. Added `lint.yml` GitHub action to run these
+   checks. Fixed all `clang-tidy` and `iwyu` warnings except for `fileutil.c`
+   with platform related include complications. Added consistent include
+   guards to all headers. Updated and improved documentation in
+   CONTRIBUTING.md to include these changes. (rizsotto, dbaarda,
+   https://github.com/librsync/librsync/pull/229)
+
+ * Tidy rdiff integration test scripts. Made the filenames and shell arguments
+   for test scripts consistent. (dbaarda,
+   https://github.com/librsync/librsync/pull/227)
+
+ * Add better cmake build type configuration support. Added `BuildType.cmake`
+   with better support for selecting the build type and making it default to
+   Debug. (dbaarda, https://github.com/librsync/librsync/pull/226)
+
+ * Fix #215 Migrate from Travis to GitHub Actions. Added a check.yml GitHub
+   action with updated test/platform matrix including full testing of rdiff on
+   Windows. (rizsotto, dbaarda, https://github.com/librsync/librsync/pull/225)
+
+ * Fix bash test scripts to work on Windows. Tweaked cmake configuration and
+   bash script tests so that full rdiff tests using libpopt from vcpkg work.
+   Running `cmake --target check` with rdiff compiled now works on windows.
+   (dbaarda, https://github.com/librsync/librsync/pull/224)
+
+ * Remove obsolete unused tests. Removed some obsolete mdfour test data files
+   and `check-rdiff` perl script. (dbaarda,
+   https://github.com/librsync/librsync/pull/223)
+
+ * Fix warning for later CMake versions. New CMake versions started
+   complaining about the filename `Findlibb2.cmake` not matching the LIBB2
+   variables being used. (rizsotto,
+   https://github.com/librsync/librsync/pull/221)
+
 ## librsync 2.3.2
 
 Released 2021-04-10

--- a/src/base64.c
+++ b/src/base64.c
@@ -19,7 +19,6 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-#include "config.h"
 #include <stdlib.h>
 #include <string.h>
 #include "librsync.h"

--- a/src/buf.c
+++ b/src/buf.c
@@ -36,7 +36,6 @@
  *
  * \todo Perhaps expose a routine for shuffling the buffers. */
 
-#include "config.h"
 #include <assert.h>
 #include <stdlib.h>
 #include <errno.h>

--- a/src/buf.h
+++ b/src/buf.h
@@ -21,6 +21,9 @@
 #ifndef BUF_H
 #  define BUF_H
 
+#  include <stdio.h>
+#  include "librsync.h"
+
 typedef struct rs_filebuf rs_filebuf_t;
 
 rs_filebuf_t *rs_filebuf_new(FILE *f, size_t buf_len);

--- a/src/buf.h
+++ b/src/buf.h
@@ -18,6 +18,8 @@
  * License along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
+#ifndef BUF_H
+#  define BUF_H
 
 typedef struct rs_filebuf rs_filebuf_t;
 
@@ -28,3 +30,5 @@ void rs_filebuf_free(rs_filebuf_t *fb);
 rs_result rs_infilebuf_fill(rs_job_t *, rs_buffers_t *buf, void *fb);
 
 rs_result rs_outfilebuf_drain(rs_job_t *, rs_buffers_t *, void *fb);
+
+#endif                          /* !BUF_H */

--- a/src/checksum.c
+++ b/src/checksum.c
@@ -21,9 +21,10 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-#include "config.h"
+#include <stdint.h>
 #include "checksum.h"
 #include "blake2.h"
+#include "librsync_export.h"
 
 LIBRSYNC_EXPORT const int RS_MD4_SUM_LENGTH = 16;
 LIBRSYNC_EXPORT const int RS_BLAKE2_SUM_LENGTH = 32;

--- a/src/checksum.h
+++ b/src/checksum.h
@@ -20,7 +20,9 @@
  */
 #ifndef CHECKSUM_H
 #  define CHECKSUM_H
+
 #  include <assert.h>
+#  include <stddef.h>
 #  include "librsync.h"
 #  include "rollsum.h"
 #  include "rabinkarp.h"

--- a/src/checksum.h
+++ b/src/checksum.h
@@ -18,8 +18,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
-#ifndef _CHECKSUM_H_
-#  define _CHECKSUM_H_
+#ifndef CHECKSUM_H
+#  define CHECKSUM_H
 #  include <assert.h>
 #  include "librsync.h"
 #  include "rollsum.h"
@@ -133,4 +133,4 @@ rs_weak_sum_t rs_calc_weak_sum(weaksum_kind_t kind, void const *buf,
 void rs_calc_strong_sum(strongsum_kind_t kind, void const *buf, size_t len,
                         rs_strong_sum_t *sum);
 
-#endif                          /* _CHECKSUM_H_ */
+#endif                          /* !CHECKSUM_H */

--- a/src/command.c
+++ b/src/command.c
@@ -19,10 +19,7 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-#include "config.h"
-#include <assert.h>
-#include <stdlib.h>
-#include "librsync.h"
+#include <stddef.h>
 #include "command.h"
 
 /* For debugging purposes, here are some human-readable forms. */

--- a/src/command.h
+++ b/src/command.h
@@ -25,6 +25,8 @@
  *
  * The vague idea is that eventually this file will be more abstract than
  * protocol.h, but it's not clear that will ever be required. */
+#ifndef COMMAND_H
+#  define COMMAND_H
 
 /** Classes of operation that can be present. Each may have several different
  * possible representations. */
@@ -47,3 +49,5 @@ typedef struct rs_op_kind_name {
 } rs_op_kind_name_t;
 
 char const *rs_op_kind_name(enum rs_op_kind);
+
+#endif                          /* !COMMAND_H */

--- a/src/delta.c
+++ b/src/delta.c
@@ -88,7 +88,6 @@
  * and scoop_pos adjusted. Everything gets complicated because the tube can
  * block. When the tube is blocked, no data can be processed. */
 
-#include "config.h"
 #include <assert.h>
 #include <stdlib.h>
 #include "librsync.h"

--- a/src/emit.c
+++ b/src/emit.c
@@ -25,14 +25,11 @@
  * \todo Pluggable encoding formats: gdiff-style, rsync 24, ed (text), Delta
  * HTTP. */
 
-#include "config.h"
 #include <assert.h>
-#include <stdlib.h>
 #include "librsync.h"
 #include "emit.h"
 #include "job.h"
 #include "netint.h"
-#include "command.h"
 #include "prototab.h"
 #include "trace.h"
 

--- a/src/emit.h
+++ b/src/emit.h
@@ -21,8 +21,12 @@
 
 /** \file emit.h
  * How to emit commands to the client. */
+#ifndef EMIT_H
+#  define EMIT_H
 
 void rs_emit_delta_header(rs_job_t *);
 void rs_emit_literal_cmd(rs_job_t *, int len);
 void rs_emit_end_cmd(rs_job_t *);
 void rs_emit_copy_cmd(rs_job_t *job, rs_long_t where, rs_long_t len);
+
+#endif                          /* !EMIT_H */

--- a/src/emit.h
+++ b/src/emit.h
@@ -24,6 +24,8 @@
 #ifndef EMIT_H
 #  define EMIT_H
 
+#  include "librsync.h"
+
 void rs_emit_delta_header(rs_job_t *);
 void rs_emit_literal_cmd(rs_job_t *, int len);
 void rs_emit_end_cmd(rs_job_t *);

--- a/src/fileutil.c
+++ b/src/fileutil.c
@@ -21,7 +21,6 @@
  */
 
 #include "config.h"
-#include <assert.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -17,8 +17,8 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA. */
-#ifndef _HASHTABLE_H_
-#  define _HASHTABLE_H_
+#ifndef HASHTABLE_H
+#  define HASHTABLE_H
 
 #  include <assert.h>
 #  include <stdlib.h>
@@ -185,7 +185,7 @@ static inline unsigned nozero(unsigned h)
     return h ? h : (unsigned)-1;
 }
 
-#endif                          /* _HASHTABLE_H_ */
+#endif                          /* !HASHTABLE_H */
 
 /* If ENTRY is defined, define type-dependent static inline methods. */
 #ifdef ENTRY

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -17,12 +17,6 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA. */
-#ifndef HASHTABLE_H
-#  define HASHTABLE_H
-
-#  include <assert.h>
-#  include <stdlib.h>
-#  include <stdbool.h>
 
 /** \file hashtable.h
  * A generic open addressing hashtable.
@@ -125,6 +119,12 @@
  * can mutate the mymatch_t object for doing things like deferred and cached
  * evaluation of expensive match data. It can also access the whole myentry_t
  * object to match against more than just the key. */
+#ifndef HASHTABLE_H
+#  define HASHTABLE_H
+
+#  include <assert.h>
+#  include <stdlib.h>
+#  include <stdbool.h>
 
 /** The hashtable type. */
 typedef struct hashtable {

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -122,8 +122,6 @@
 #ifndef HASHTABLE_H
 #  define HASHTABLE_H
 
-#  include <assert.h>
-#  include <stdlib.h>
 #  include <stdbool.h>
 
 /** The hashtable type. */
@@ -189,6 +187,9 @@ static inline unsigned nozero(unsigned h)
 
 /* If ENTRY is defined, define type-dependent static inline methods. */
 #ifdef ENTRY
+
+#  include <assert.h>
+#  include <stddef.h>
 
 #  define _JOIN2(x, y) x##y
 #  define _JOIN(x, y) _JOIN2(x, y)

--- a/src/hex.c
+++ b/src/hex.c
@@ -17,7 +17,6 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-#include "config.h"
 #include "librsync.h"
 
 void rs_hexify(char *to_buf, void const *from, int from_len)

--- a/src/isprefix.h
+++ b/src/isprefix.h
@@ -23,4 +23,4 @@
 /** Return true if TIP is a prefix of ICEBERG. */
 int isprefix(char const *tip, char const *iceberg);
 
-endif                           /* !ISPREFIX_H */
+#endif                          /* !ISPREFIX_H */

--- a/src/isprefix.h
+++ b/src/isprefix.h
@@ -17,6 +17,10 @@
  * License along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
+#ifndef ISPREFIX_H
+#  define ISPREFIX_H
 
 /** Return true if TIP is a prefix of ICEBERG. */
 int isprefix(char const *tip, char const *iceberg);
+
+endif                           /* !ISPREFIX_H */

--- a/src/job.c
+++ b/src/job.c
@@ -33,7 +33,6 @@
  *
  * \sa \ref api_streaming \sa rs_job_iter() \sa ::rs_job */
 
-#include "config.h"
 #include <assert.h>
 #include <stdlib.h>
 #include <time.h>

--- a/src/job.h
+++ b/src/job.h
@@ -113,4 +113,4 @@ int rs_job_input_is_ending(rs_job_t *job);
     assert(job->dogtag == RS_JOB_TAG);\
 } while (0)
 
-endif                           /* !JOB_H */
+#endif                          /* !JOB_H */

--- a/src/job.h
+++ b/src/job.h
@@ -18,9 +18,11 @@
  * License along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
+#ifndef JOB_H
+#  define JOB_H
 
-#include "mdfour.h"
-#include "checksum.h"
+#  include "mdfour.h"
+#  include "checksum.h"
 
 /** The contents of this structure are private. */
 struct rs_job {
@@ -101,12 +103,14 @@ rs_job_t *rs_job_new(const char *, rs_result (*statefn)(rs_job_t *));
 int rs_job_input_is_ending(rs_job_t *job);
 
 /** Magic job tag number for checking jobs have been initialized. */
-#define RS_JOB_TAG 20010225
+#  define RS_JOB_TAG 20010225
 
 /** Assert that a job is valid.
  *
  * We don't use a static inline function here so that assert failure output
  * points at where rs_job_check() was called from. */
-#define rs_job_check(job) do {\
+#  define rs_job_check(job) do {\
     assert(job->dogtag == RS_JOB_TAG);\
 } while (0)
+
+endif                           /* !JOB_H */

--- a/src/job.h
+++ b/src/job.h
@@ -21,8 +21,11 @@
 #ifndef JOB_H
 #  define JOB_H
 
+#  include <assert.h>
+#  include <stddef.h>
 #  include "mdfour.h"
 #  include "checksum.h"
+#  include "librsync.h"
 
 /** The contents of this structure are private. */
 struct rs_job {

--- a/src/librsync.h
+++ b/src/librsync.h
@@ -29,8 +29,8 @@
 
 /** \file librsync.h
  * Public header for librsync. */
-#ifndef _RSYNC_H
-#  define _RSYNC_H
+#ifndef LIBRSYNC_H
+#  define LIBRSYNC_H
 
 #  include <stdio.h>
 #  include <stdint.h>
@@ -611,4 +611,4 @@ LIBRSYNC_EXPORT rs_result rs_patch_file(FILE *basis_file, FILE *delta_file,
 }                               /* extern "C" */
 #  endif
 
-#endif                          /* !_RSYNC_H */
+#endif                          /* !LIBRSYNC_H */

--- a/src/librsync_export.h
+++ b/src/librsync_export.h
@@ -15,4 +15,4 @@
 #    endif
 #  endif
 
-#endif                          /* LIBRSYNC_EXPORT_H */
+#endif                          /* !LIBRSYNC_EXPORT_H */

--- a/src/mdfour.c
+++ b/src/mdfour.c
@@ -39,8 +39,6 @@
  * 2004-09-09: Simon Law <sfllaw@debian.org> handle little-endian machines that
  * can't do unaligned access (e.g. ia64, pa-risc). */
 
-#include "config.h"
-#include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
 #include "librsync.h"

--- a/src/mdfour.h
+++ b/src/mdfour.h
@@ -19,15 +19,19 @@
  * License along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
+#ifndef MDFOUR_H
+#  define MDFOUR_H
 
 /** \private Internal state while computing an MD4 hash. */
 struct rs_mdfour {
     unsigned int A, B, C, D;
-#ifdef UINT64_MAX
+#  ifdef UINT64_MAX
     uint64_t totalN;
-#else
+#  else
     uint32_t totalN_hi, totalN_lo;
-#endif
+#  endif
     int tail_len;
     unsigned char tail[64];
 };
+
+endif                           /* !MDFOUR_H */

--- a/src/mdfour.h
+++ b/src/mdfour.h
@@ -34,4 +34,4 @@ struct rs_mdfour {
     unsigned char tail[64];
 };
 
-endif                           /* !MDFOUR_H */
+#endif                          /* !MDFOUR_H */

--- a/src/mdfour.h
+++ b/src/mdfour.h
@@ -22,6 +22,8 @@
 #ifndef MDFOUR_H
 #  define MDFOUR_H
 
+#  include <stdint.h>
+
 /** \private Internal state while computing an MD4 hash. */
 struct rs_mdfour {
     unsigned int A, B, C, D;

--- a/src/mksum.c
+++ b/src/mksum.c
@@ -27,8 +27,6 @@
  * whatever data is available. When a whole block has arrived, or we've reached
  * the end of the file, we write the checksum out. */
 
-#include "config.h"
-#include <assert.h>
 #include <stdlib.h>
 #include "librsync.h"
 #include "job.h"

--- a/src/msg.c
+++ b/src/msg.c
@@ -40,7 +40,6 @@
  * description of a job, including only the fields relevant to the current
  * encoding function. */
 
-#include "config.h"
 #include "librsync.h"
 
 char const *rs_strerror(rs_result r)

--- a/src/netint.c
+++ b/src/netint.c
@@ -38,9 +38,7 @@
  * RS_BLOCKED if there is not enough output space to proceed, but in practice
  * is always RS_DONE. */
 
-#include "config.h"
 #include <assert.h>
-#include <stdlib.h>
 #include "librsync.h"
 #include "netint.h"
 #include "stream.h"

--- a/src/netint.h
+++ b/src/netint.h
@@ -32,4 +32,4 @@ rs_result rs_suck_n4(rs_job_t *job, int *val);
 
 int rs_int_len(rs_long_t val);
 
-endif                           /* !NETINT_H */
+#endif                          /* !NETINT_H */

--- a/src/netint.h
+++ b/src/netint.h
@@ -19,6 +19,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
+#ifndef NETINT_H
+#  define NETINT_H
 
 rs_result rs_squirt_byte(rs_job_t *job, rs_byte_t val);
 rs_result rs_squirt_netint(rs_job_t *job, rs_long_t val, int len);
@@ -29,3 +31,5 @@ rs_result rs_suck_netint(rs_job_t *job, rs_long_t *val, int len);
 rs_result rs_suck_n4(rs_job_t *job, int *val);
 
 int rs_int_len(rs_long_t val);
+
+endif                           /* !NETINT_H */

--- a/src/netint.h
+++ b/src/netint.h
@@ -22,6 +22,8 @@
 #ifndef NETINT_H
 #  define NETINT_H
 
+#  include "librsync.h"
+
 rs_result rs_squirt_byte(rs_job_t *job, rs_byte_t val);
 rs_result rs_squirt_netint(rs_job_t *job, rs_long_t val, int len);
 rs_result rs_squirt_n4(rs_job_t *job, int val);

--- a/src/patch.c
+++ b/src/patch.c
@@ -23,10 +23,10 @@
                                | This is Tranquility Base.
                                */
 
-#include "config.h"
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
 #include "librsync.h"
 #include "job.h"
 #include "netint.h"

--- a/src/prototab.c
+++ b/src/prototab.c
@@ -27,8 +27,6 @@
  * implied literal value, and length of the first and second parameters. The
  * implied value is only used if the first parameter length is zero. */
 
-#include "config.h"
-#include "librsync.h"
 #include "command.h"
 #include "prototab.h"
 

--- a/src/prototab.h
+++ b/src/prototab.h
@@ -300,4 +300,4 @@ enum {
     RS_OP_RESERVED_255 = 0xff
 };
 
-endif                           /* !PROTOTAB_H */
+#endif                          /* !PROTOTAB_H */

--- a/src/prototab.h
+++ b/src/prototab.h
@@ -33,6 +33,8 @@
 #ifndef PROTOTAB_H
 #  define PROTOTAB_H
 
+#  include "command.h"
+
 typedef struct rs_prototab_ent {
     enum rs_op_kind kind;
     int immediate;

--- a/src/prototab.h
+++ b/src/prototab.h
@@ -30,6 +30,8 @@
 
 /** \file prototab.h
  * Delta file commands. */
+#ifndef PROTOTAB_H
+#  define PROTOTAB_H
 
 typedef struct rs_prototab_ent {
     enum rs_op_kind kind;
@@ -297,3 +299,5 @@ enum {
     RS_OP_RESERVED_254 = 0xfe,
     RS_OP_RESERVED_255 = 0xff
 };
+
+endif                           /* !PROTOTAB_H */

--- a/src/rabinkarp.h
+++ b/src/rabinkarp.h
@@ -18,8 +18,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
-#ifndef _RABINKARP_H_
-#  define _RABINKARP_H_
+#ifndef RABINKARP_H
+#  define RABINKARP_H
 
 #  include <stddef.h>
 #  include <stdint.h>
@@ -91,4 +91,4 @@ static inline uint32_t rabinkarp_digest(rabinkarp_t *sum)
     return sum->hash;
 }
 
-#endif                          /* _RABINKARP_H_ */
+#endif                          /* !RABINKARP_H */

--- a/src/rdiff.c
+++ b/src/rdiff.c
@@ -43,11 +43,12 @@
  *
  * \todo Add an option for delta to check whether the files are identical. */
 
-#include "config.h"
 #include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>
 #include <popt.h>
+#include <stdio.h>
+#include "config.h"
 #include "librsync.h"
 #include "isprefix.h"
 

--- a/src/readsums.c
+++ b/src/readsums.c
@@ -23,9 +23,6 @@
 /** \file readsums.c
  * Load signatures from a file. */
 
-#include "config.h"
-#include <assert.h>
-#include <stdlib.h>
 #include "librsync.h"
 #include "job.h"
 #include "sumset.h"

--- a/src/rollsum.h
+++ b/src/rollsum.h
@@ -19,8 +19,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
-#ifndef _ROLLSUM_H_
-#  define _ROLLSUM_H_
+#ifndef ROLLSUM_H
+#  define ROLLSUM_H
 
 #  include <stddef.h>
 #  include <stdint.h>
@@ -71,4 +71,4 @@ static inline uint32_t RollsumDigest(Rollsum *sum)
     return ((uint32_t)sum->s2 << 16) | ((uint32_t)sum->s1 & 0xffff);
 }
 
-#endif                          /* _ROLLSUM_H_ */
+#endif                          /* !ROLLSUM_H */

--- a/src/scoop.c
+++ b/src/scoop.c
@@ -53,7 +53,6 @@
  * would be kind of nice to not do any memory allocation after startup, as
  * bzlib does this. */
 
-#include "config.h"
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/stats.c
+++ b/src/stats.c
@@ -23,7 +23,6 @@
  * \todo Other things to show in statistics: number of input and output bytes,
  * number of times we blocked waiting for input or output, number of blocks. */
 
-#include "config.h"
 #include <stdio.h>
 #include "librsync.h"
 #include "trace.h"

--- a/src/stats.c
+++ b/src/stats.c
@@ -84,10 +84,8 @@ char *rs_format_stats(rs_stats_t const *stats, char *buf, size_t size)
         sec = 1;                // avoid division by zero
     mb_in = (double)stats->in_bytes / 1e6;
     mb_out = (double)stats->out_bytes / 1e6;
-    len +=
-        snprintf(buf + len, size - (size_t)len,
-                 " speed[%.1f MB (%.1f MB/s) in, %.1f MB (%.1f MB/s) out, %d sec]",
-                 mb_in, mb_in / sec, mb_out, mb_out / sec, sec);
-
+    snprintf(buf + len, size - (size_t)len,
+             " speed[%.1f MB (%.1f MB/s) in, %.1f MB (%.1f MB/s) out, %d sec]",
+             mb_in, mb_in / sec, mb_out, mb_out / sec, sec);
     return buf;
 }

--- a/src/stream.h
+++ b/src/stream.h
@@ -73,6 +73,8 @@
  * On each call into a stream iterator, it should begin by trying to flush
  * output. This may well use up all the remaining stream space, in which case
  * nothing else can be done. */
+#ifndef STREAM_H
+#  define STREAM_H
 
 size_t rs_buffers_copy(rs_buffers_t *stream, size_t len);
 
@@ -87,3 +89,5 @@ rs_result rs_scoop_readahead(rs_job_t *job, size_t len, void **ptr);
 rs_result rs_scoop_read(rs_job_t *job, size_t len, void **ptr);
 rs_result rs_scoop_read_rest(rs_job_t *job, size_t *len, void **ptr);
 size_t rs_scoop_total_avail(rs_job_t *job);
+
+endif                           /* !STREAM_H */

--- a/src/stream.h
+++ b/src/stream.h
@@ -90,4 +90,4 @@ rs_result rs_scoop_read(rs_job_t *job, size_t len, void **ptr);
 rs_result rs_scoop_read_rest(rs_job_t *job, size_t *len, void **ptr);
 size_t rs_scoop_total_avail(rs_job_t *job);
 
-endif                           /* !STREAM_H */
+#endif                          /* !STREAM_H */

--- a/src/sumset.c
+++ b/src/sumset.c
@@ -20,8 +20,6 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-#include "config.h"
-#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 #include "librsync.h"

--- a/src/sumset.h
+++ b/src/sumset.h
@@ -135,4 +135,4 @@ static inline void rs_signature_calc_strong_sum(rs_signature_t const *sig,
     rs_calc_strong_sum(rs_signature_strongsum_kind(sig), buf, len, sum);
 }
 
-endif                           /* !SUMSET_H */
+#endif                          /* !SUMSET_H */

--- a/src/sumset.h
+++ b/src/sumset.h
@@ -19,10 +19,12 @@
  * License along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
+#ifndef SUMSET_H
+#  define SUMSET_H
 
-#include <assert.h>
-#include "hashtable.h"
-#include "checksum.h"
+#  include <assert.h>
+#  include "hashtable.h"
+#  include "checksum.h"
 
 /** Signature of a single block. */
 typedef struct rs_block_sig {
@@ -43,9 +45,9 @@ struct rs_signature {
     void *block_sigs;           /**< The packed block_sigs for all blocks. */
     hashtable_t *hashtable;     /**< The hashtable for finding matches. */
     /* The is extra stats not included in the hashtable stats. */
-#ifndef HASHTABLE_NSTATS
+#  ifndef HASHTABLE_NSTATS
     long calc_strong_count;     /**< The count of strongsum calcs done. */
-#endif
+#  endif
 };
 
 /** Initialize an rs_signature instance.
@@ -82,7 +84,7 @@ rs_long_t rs_signature_find_match(rs_signature_t *sig, rs_weak_sum_t weak_sum,
  *
  * We don't use a static inline function here so that assert failure output
  * points at where rs_sig_args_check() was called from. */
-#define rs_sig_args_check(magic, block_len, strong_len) do {\
+#  define rs_sig_args_check(magic, block_len, strong_len) do {\
     assert(((magic) & ~0xff) == (RS_MD4_SIG_MAGIC & ~0xff));\
     assert(((magic) & 0xf0) == 0x30 || ((magic) & 0xf0) == 0x40);\
     assert((((magic) & 0x0f) == 0x06 &&\
@@ -97,7 +99,7 @@ rs_long_t rs_signature_find_match(rs_signature_t *sig, rs_weak_sum_t weak_sum,
  *
  * We don't use a static inline function here so that assert failure output
  * points at where rs_signature_check() was called from. */
-#define rs_signature_check(sig) do {\
+#  define rs_signature_check(sig) do {\
     rs_sig_args_check((sig)->magic, (sig)->block_len, (sig)->strong_sum_len);\
     assert(0 <= (sig)->count && (sig)->count <= (sig)->size);\
     assert(!(sig)->hashtable || (sig)->hashtable->count <= (sig)->count);\
@@ -132,3 +134,5 @@ static inline void rs_signature_calc_strong_sum(rs_signature_t const *sig,
 {
     rs_calc_strong_sum(rs_signature_strongsum_kind(sig), buf, len, sum);
 }
+
+endif                           /* !SUMSET_H */

--- a/src/sumset.h
+++ b/src/sumset.h
@@ -23,8 +23,10 @@
 #  define SUMSET_H
 
 #  include <assert.h>
+#  include <stddef.h>
 #  include "hashtable.h"
 #  include "checksum.h"
+#  include "librsync.h"
 
 /** Signature of a single block. */
 typedef struct rs_block_sig {

--- a/src/trace.c
+++ b/src/trace.c
@@ -32,11 +32,9 @@
  * \todo Have a bit set in the log level that says not to include the function
  * name. */
 
-#include "config.h"
-#include <assert.h>
-#include <stdlib.h>
 #include <stdio.h>
 #include <stdarg.h>
+#include "config.h"
 #include "librsync.h"
 #include "trace.h"
 #include "util.h"

--- a/src/trace.h
+++ b/src/trace.h
@@ -35,6 +35,8 @@
 #  define TRACE_H
 
 #  include <inttypes.h>
+#  include "config.h"
+
 /* Printf format patters for standard librsync types. */
 #  define FMT_LONG "%"PRIdMAX
 #  define FMT_WEAKSUM "%08"PRIx32

--- a/src/trace.h
+++ b/src/trace.h
@@ -87,4 +87,4 @@ enum {
 
 extern int rs_trace_level;
 
-endif                           /* !TRACE_H */
+#endif                          /* !TRACE_H */

--- a/src/trace.h
+++ b/src/trace.h
@@ -31,49 +31,51 @@
  * \todo A function like perror that includes strerror output. Apache does this
  * by adding flags as well as the severity level which say whether such
  * information should be included. */
+#ifndef TRACE_H
+#  define TRACE_H
 
-#include <inttypes.h>
+#  include <inttypes.h>
 /* Printf format patters for standard librsync types. */
-#define FMT_LONG "%"PRIdMAX
-#define FMT_WEAKSUM "%08"PRIx32
+#  define FMT_LONG "%"PRIdMAX
+#  define FMT_WEAKSUM "%08"PRIx32
 /* Old MSVC compilers don't support "%zu" and have "%Iu" instead. */
-#ifdef HAVE_PRINTF_Z
-#  define FMT_SIZE "%zu"
-#else
-#  define FMT_SIZE "%Iu"
-#endif
+#  ifdef HAVE_PRINTF_Z
+#    define FMT_SIZE "%zu"
+#  else
+#    define FMT_SIZE "%Iu"
+#  endif
 
 /* Some old compilers don't support __func_ and have __FUNCTION__ instead. */
-#ifndef HAVE___FUNC__
-#  ifdef HAVE___FUNCTION__
-#    define __func__ __FUNCTION__
-#  else
-#    define __func__ ""
+#  ifndef HAVE___FUNC__
+#    ifdef HAVE___FUNCTION__
+#      define __func__ __FUNCTION__
+#    else
+#      define __func__ ""
+#    endif
 #  endif
-#endif
 
 /* Non-GNUC compatible compilers don't support __attribute__(). */
-#ifndef __GNUC__
-#  define __attribute__(x)
-#endif
+#  ifndef __GNUC__
+#    define __attribute__(x)
+#  endif
 
 void rs_log0(int level, char const *fn, char const *fmt, ...)
     __attribute__((format(printf, 3, 4)));
 
 /** \def rs_trace_enabled()
  * Call this before putting too much effort into generating trace messages. */
-#ifdef DO_RS_TRACE
-#  define rs_trace_enabled() ((rs_trace_level & RS_LOG_PRIMASK) >= RS_LOG_DEBUG)
-#  define rs_trace(...) rs_log0(RS_LOG_DEBUG, __func__, __VA_ARGS__)
-#else
-#  define rs_trace_enabled() 0
-#  define rs_trace(...)
-#endif                          /* !DO_RS_TRACE */
+#  ifdef DO_RS_TRACE
+#    define rs_trace_enabled() ((rs_trace_level & RS_LOG_PRIMASK) >= RS_LOG_DEBUG)
+#    define rs_trace(...) rs_log0(RS_LOG_DEBUG, __func__, __VA_ARGS__)
+#  else
+#    define rs_trace_enabled() 0
+#    define rs_trace(...)
+#  endif                        /* !DO_RS_TRACE */
 
-#define rs_log(l, ...) rs_log0((l), __func__, __VA_ARGS__)
-#define rs_warn(...) rs_log0(RS_LOG_WARNING, __func__, __VA_ARGS__)
-#define rs_error(...) rs_log0(RS_LOG_ERR,  __func__, __VA_ARGS__)
-#define rs_fatal(...) do { \
+#  define rs_log(l, ...) rs_log0((l), __func__, __VA_ARGS__)
+#  define rs_warn(...) rs_log0(RS_LOG_WARNING, __func__, __VA_ARGS__)
+#  define rs_error(...) rs_log0(RS_LOG_ERR,  __func__, __VA_ARGS__)
+#  define rs_fatal(...) do { \
     rs_log0(RS_LOG_CRIT, __func__, __VA_ARGS__); \
     abort(); \
 } while (0)
@@ -84,3 +86,5 @@ enum {
 };
 
 extern int rs_trace_level;
+
+endif                           /* !TRACE_H */

--- a/src/tube.c
+++ b/src/tube.c
@@ -51,7 +51,6 @@
  * in that case we might need to copy into some temporary buffer space, and
  * then back out again later. */
 
-#include "config.h"
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/util.c
+++ b/src/util.c
@@ -23,7 +23,6 @@
                                  | On heroin, I have all the answers.
                                  */
 
-#include "config.h"
 #include <stdlib.h>
 #include <string.h>
 #include "librsync.h"

--- a/src/util.h
+++ b/src/util.h
@@ -43,4 +43,4 @@ int rs_long_sqrt(rs_long_t v);
 #    define UNUSED(x) x
 #  endif                        /* !__GNUC__ && !__LCLINT__ */
 
-endif                           /* !UTIL_H */
+#endif                          /* !UTIL_H */

--- a/src/util.h
+++ b/src/util.h
@@ -19,6 +19,8 @@
  * License along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
+#ifndef UTIL_H
+#  define UTIL_H
 
 void *rs_alloc(size_t size, char const *name);
 void *rs_realloc(void *ptr, size_t size, char const *name);
@@ -30,13 +32,15 @@ int rs_long_ln2(rs_long_t v);
 int rs_long_sqrt(rs_long_t v);
 
 /** Allocate and zero-fill an instance of TYPE. */
-#define rs_alloc_struct(type)				\
+#  define rs_alloc_struct(type)				\
         ((type *) rs_alloc_struct0(sizeof(type), #type))
 
-#ifdef __GNUC__
-#  define UNUSED(x) x __attribute__((unused))
-#elif defined(__LCLINT__) || defined(S_SPLINT_S)
-#  define UNUSED(x) /*@unused@*/ x
-#else                           /* !__GNUC__ && !__LCLINT__ */
-#  define UNUSED(x) x
-#endif                          /* !__GNUC__ && !__LCLINT__ */
+#  ifdef __GNUC__
+#    define UNUSED(x) x __attribute__((unused))
+#  elif defined(__LCLINT__) || defined(S_SPLINT_S)
+#    define UNUSED(x) /*@unused@*/ x
+#  else                         /* !__GNUC__ && !__LCLINT__ */
+#    define UNUSED(x) x
+#  endif                        /* !__GNUC__ && !__LCLINT__ */
+
+endif                           /* !UTIL_H */

--- a/src/util.h
+++ b/src/util.h
@@ -22,6 +22,9 @@
 #ifndef UTIL_H
 #  define UTIL_H
 
+#  include <stddef.h>
+#  include "librsync.h"
+
 void *rs_alloc(size_t size, char const *name);
 void *rs_realloc(void *ptr, size_t size, char const *name);
 void *rs_alloc_struct0(size_t size, char const *name);

--- a/src/whole.c
+++ b/src/whole.c
@@ -27,9 +27,6 @@
                                |        -- Alan Perlis
                                */
 
-#include "config.h"
-#include <assert.h>
-#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include "librsync.h"
@@ -37,6 +34,7 @@
 #include "sumset.h"
 #include "job.h"
 #include "buf.h"
+#include "librsync_export.h"
 
 /** Whole file IO buffer sizes. */
 LIBRSYNC_EXPORT int rs_inbuflen = 0, rs_outbuflen = 0;

--- a/src/whole.h
+++ b/src/whole.h
@@ -18,6 +18,10 @@
  * License along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
+#ifndef WHOLE_H
+#  define WHOLE_H
 
 rs_result rs_whole_run(rs_job_t *job, FILE *in_file, FILE *out_file,
                        int inbuflen, int outbuflen);
+
+endif                           /* !WHOLE_H */

--- a/src/whole.h
+++ b/src/whole.h
@@ -21,6 +21,9 @@
 #ifndef WHOLE_H
 #  define WHOLE_H
 
+#  include <stdio.h>
+#  include "librsync.h"
+
 rs_result rs_whole_run(rs_job_t *job, FILE *in_file, FILE *out_file,
                        int inbuflen, int outbuflen);
 

--- a/src/whole.h
+++ b/src/whole.h
@@ -24,4 +24,4 @@
 rs_result rs_whole_run(rs_job_t *job, FILE *in_file, FILE *out_file,
                        int inbuflen, int outbuflen);
 
-endif                           /* !WHOLE_H */
+#endif                          /* !WHOLE_H */

--- a/tests/checksum_test.c
+++ b/tests/checksum_test.c
@@ -21,11 +21,11 @@
 
 /* Force DEBUG on so that tests can use assert(). */
 #undef NDEBUG
-#include <stdio.h>
-#include <stdint.h>
 #include <assert.h>
 #include <string.h>
 #include "checksum.h"
+#include "hashtable.h"
+#include "librsync.h"
 
 /* Test driver for rollsum. */
 int main(int argc, char **argv)

--- a/tests/hashtable_test.c
+++ b/tests/hashtable_test.c
@@ -21,9 +21,8 @@
 
 /* Force DEBUG on so that tests can use assert(). */
 #undef NDEBUG
-#include <stdio.h>
-#include <stdint.h>
 #include <assert.h>
+#include <stddef.h>
 #include "hashtable.h"
 
 /* Key type for the hashtable. */

--- a/tests/isprefix_test.c
+++ b/tests/isprefix_test.c
@@ -20,11 +20,7 @@
 
 /* Force DEBUG on so that tests can use assert(). */
 #undef NDEBUG
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <assert.h>
-
 #include "isprefix.h"
 
 /* Test driver for isprefix. */

--- a/tests/netint_test.c
+++ b/tests/netint_test.c
@@ -21,7 +21,6 @@
 /* Force DEBUG on so that tests can use assert(). */
 #undef NDEBUG
 #include <assert.h>
-#include <stdlib.h>
 #include <stdint.h>
 #include "librsync.h"
 #include "netint.h"

--- a/tests/rabinkarp_test.c
+++ b/tests/rabinkarp_test.c
@@ -21,8 +21,6 @@
 
 /* Force DEBUG on so that tests can use assert(). */
 #undef NDEBUG
-#include <stdio.h>
-#include <stdint.h>
 #include <assert.h>
 #include "rabinkarp.h"
 

--- a/tests/rollsum_test.c
+++ b/tests/rollsum_test.c
@@ -21,8 +21,6 @@
 
 /* Force DEBUG on so that tests can use assert(). */
 #undef NDEBUG
-#include <stdio.h>
-#include <stdint.h>
 #include <assert.h>
 #include "rollsum.h"
 

--- a/tests/sumset_test.c
+++ b/tests/sumset_test.c
@@ -21,11 +21,11 @@
 
 /* Force DEBUG on so that tests can use assert(). */
 #undef NDEBUG
-#include "config.h"
 #include <string.h>
 #include <assert.h>
 #include "librsync.h"
 #include "sumset.h"
+#include "hashtable.h"
 
 /* Test driver for sumset.c. */
 int main(int argc, char **argv)

--- a/tests/sumset_test.c
+++ b/tests/sumset_test.c
@@ -238,15 +238,18 @@ int main(int argc, char **argv)
 
     /* Test rs_signature_calc_strong_sum(). */
     res = rs_signature_init(&sig, RS_MD4_SIG_MAGIC, 16, 6, -1);
+    assert(res == RS_DONE);
     rs_signature_calc_strong_sum(&sig, &buf, 256, &strong);
     assert(memcmp(&strong, "\x29\x8a\x05\xbc\x50\x6e", 6) == 0);
 
     res = rs_signature_init(&sig, RS_BLAKE2_SIG_MAGIC, 16, 6, -1);
+    assert(res == RS_DONE);
     rs_signature_calc_strong_sum(&sig, &buf, 256, &strong);
     assert(memcmp(&strong, "\x39\xa7\xeb\x9f\xed\xc1", 6) == 0);
 
     /* Test rs_signature_add_block(). */
     res = rs_signature_init(&sig, 0, 16, 6, -1);
+    assert(res == RS_DONE);
     rs_signature_add_block(&sig, weak, &strong);
     assert(sig.count == 1);
     assert(sig.size == 16);
@@ -258,6 +261,7 @@ int main(int argc, char **argv)
 
     /* Prepare rs_build_hash_table() and rs_signature_find_match() tests. */
     res = rs_signature_init(&sig, 0, 16, 6, -1);
+    assert(res == RS_DONE);
     for (i = 0; i < 256; i += 16) {
         weak = rs_signature_calc_weak_sum(&sig, &buf[i], 16);
         rs_signature_calc_strong_sum(&sig, &buf[i], 16, &strong);


### PR DESCRIPTION
This adds clang-tidy and iwyu make targets for linting code, and adds a lint.yml githup action to run them.

Fixes #215 and replaces #222. This takes ideas from rizsotto's #222 pull request and changes them in the following ways;

1. it drops the `analyze-build` checks which research indicates are a subset of `clang-tidy`.
2. it sets `CMAKE_EXPORT_COMPILE_COMMANDS ON` in `CMakeLists.txt` so it doesn't need to be set at the cmdline.
3. it adds `clang-tidy` and `iwyu` make targets, so that they can easily be executed at the cmdline too.
4. it puts all the lint checks into a single github action, with each check as a separate step. This should be more efficient, and just as easy or easier to check the results.
5. Adds a `iwyu-fix` make target for automatically fixing headers using `fix_include`. This skips `fileutil.c` which confuses these tools by conditionally including all the available file related headers to try and find working functions for different platforms.
6. Fixes all warnings found by `clang-tidy`. There was actually not many.
7. Fixes all the include warnings found by `iwyu` except for `fileutil.c`. This included making the include guards consistently named, adding include guards to all the headers that didn't have them, and fixing all the includes.
8. Updates `CONTRIBUTING.md` to add a **Requirements** section listing dependencies and support tools to install, and how to use the new make targets.
9. Update `NEWS.md` with changes added so far.
