### PR TITLE
Upload build and install artifacts from Github actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -40,8 +40,8 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/upload-artifact@v2
       with:
-        name: rdiff ${{ matrix.os }} ${{ matrix.build }}
-        path: build/CMakeFiles/rdiff*
+        name: build results ${{ matrix.os }} ${{ matrix.build }}
+        path: ${{github.workspace}}/build
 
     - name: Install Dependencies
       # Unfortunately available Marketplace Actions for this are in a mess, so we do it manually.

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -86,5 +86,5 @@ jobs:
         path: |
             ${{github.workspace}}/build/rdiff
             ${{github.workspace}}/build/rdiff.exe
-        if-no-files-found: error
-
+        // TODO: Skip this (to avoid warnings) in cases where rdiff is not expected to
+        // be built.

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -38,6 +38,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/upload-artifact@v2
+      with:
+        name: rdiff ${{ matrix.os }} ${{ matrix.build }}
+        path: build/rdiff*
 
     - name: Install Dependencies
       # Unfortunately available Marketplace Actions for this are in a mess, so we do it manually.
@@ -71,3 +75,4 @@ jobs:
     - name: Build docs
       if: ${{matrix.build_docs}}
       run: cmake --build '${{github.workspace}}/build' --target doc
+

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,7 +41,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: rdiff ${{ matrix.os }} ${{ matrix.build }}
-        path: build/rdiff*
+        path: build/CMakeFiles/rdiff*
 
     - name: Install Dependencies
       # Unfortunately available Marketplace Actions for this are in a mess, so we do it manually.

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -82,7 +82,7 @@ jobs:
 
     - name: Upload rdiff
       uses: actions/upload-artifact@v2
-      if: ! ${{ matrix.no_rdiff }}
+      if: ${{ ! matrix.no_rdiff }}
       with:
         name: rdiff ${{ matrix.os }} ${{ matrix.build }}
         path: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,7 +19,6 @@ jobs:
        os: [ubuntu-latest, macos-latest, windows-latest]
        build: [Release]
        options: [""]
-       has_rdiff: true
        include:
          - os: windows-latest
            os_options: "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake"
@@ -31,7 +30,7 @@ jobs:
          - os: ubuntu-latest
            build: Release
            options: "-DBUILD_RDIFF=OFF"
-           has_rdiff: false
+           no_rdiff: false
          - os: ubuntu-latest
            build: Release
            options: "-G Ninja -DCMAKE_C_COMPILER=clang"
@@ -83,7 +82,7 @@ jobs:
 
     - name: Upload rdiff
       uses: actions/upload-artifact@v2
-      if: ${{ matrix.has_rdiff }}
+      if: ! ${{ matrix.no_rdiff }}
       with:
         name: rdiff ${{ matrix.os }} ${{ matrix.build }}
         path: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,6 +19,7 @@ jobs:
        os: [ubuntu-latest, macos-latest, windows-latest]
        build: [Release]
        options: [""]
+       has_rdiff: true
        include:
          - os: windows-latest
            os_options: "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake"
@@ -30,6 +31,7 @@ jobs:
          - os: ubuntu-latest
            build: Release
            options: "-DBUILD_RDIFF=OFF"
+           has_rdiff: false
          - os: ubuntu-latest
            build: Release
            options: "-G Ninja -DCMAKE_C_COMPILER=clang"
@@ -81,10 +83,10 @@ jobs:
 
     - name: Upload rdiff
       uses: actions/upload-artifact@v2
+      if: ${{ matrix.has_rdiff }}
       with:
         name: rdiff ${{ matrix.os }} ${{ matrix.build }}
         path: |
             ${{github.workspace}}/build/rdiff
             ${{github.workspace}}/build/Release/rdiff.exe
-        # TODO: Skip this (to avoid warnings) in cases where rdiff is not expected to
-        # be built.
+        if-no-files-found: error

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -86,5 +86,5 @@ jobs:
         path: |
             ${{github.workspace}}/build/rdiff
             ${{github.workspace}}/build/rdiff.exe
-        // TODO: Skip this (to avoid warnings) in cases where rdiff is not expected to
-        // be built.
+        # TODO: Skip this (to avoid warnings) in cases where rdiff is not expected to
+        # be built.

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,7 +30,6 @@ jobs:
          - os: ubuntu-latest
            build: Release
            options: "-DBUILD_RDIFF=OFF"
-           no_rdiff: true
          - os: ubuntu-latest
            build: Release
            options: "-G Ninja -DCMAKE_C_COMPILER=clang"
@@ -68,24 +67,25 @@ jobs:
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest -C ${{matrix.build}} --output-on-failure
+      
+    - name: Build install
+      # Build your program with the given configuration.
+      run: cmake --install 'build' --config ${{matrix.build}} --prefix 'install'
 
     - name: Build docs
       if: ${{matrix.build_docs}}
       run: cmake --build '${{github.workspace}}/build' --target doc
 
-    - name: Upload artifacts
+    - name: Upload build
       uses: actions/upload-artifact@v2
       with:
-        name: build results ${{ matrix.os }} ${{ matrix.build }}
+        name: build results ${{matrix.os}} ${{matrix.build}} ${{matrix.options}}
         path: ${{github.workspace}}/build
         if-no-files-found: error
 
-    - name: Upload rdiff
+    - name: Upload install
       uses: actions/upload-artifact@v2
-      if: ${{ ! matrix.no_rdiff }}
       with:
-        name: rdiff ${{ matrix.os }} ${{ matrix.build }}
-        path: |
-            ${{github.workspace}}/build/rdiff
-            ${{github.workspace}}/build/Release/rdiff.exe
+        name: install results ${{matrix.os}} ${{matrix.build}} ${{matrix.options}}
+        path: ${{github.workspace}}/install
         if-no-files-found: error

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -85,6 +85,6 @@ jobs:
         name: rdiff ${{ matrix.os }} ${{ matrix.build }}
         path: |
             ${{github.workspace}}/build/rdiff
-            ${{github.workspace}}/build/rdiff.exe
+            ${{github.workspace}}/build/Release/rdiff.exe
         # TODO: Skip this (to avoid warnings) in cases where rdiff is not expected to
         # be built.

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,7 +30,7 @@ jobs:
          - os: ubuntu-latest
            build: Release
            options: "-DBUILD_RDIFF=OFF"
-           no_rdiff: false
+           no_rdiff: true
          - os: ubuntu-latest
            build: Release
            options: "-G Ninja -DCMAKE_C_COMPILER=clang"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -72,7 +72,7 @@ jobs:
       if: ${{matrix.build_docs}}
       run: cmake --build '${{github.workspace}}/build' --target doc
 
-    - name: Upload results
+    - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
         name: build results ${{ matrix.os }} ${{ matrix.build }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -77,3 +77,14 @@ jobs:
       with:
         name: build results ${{ matrix.os }} ${{ matrix.build }}
         path: ${{github.workspace}}/build
+        if-no-files-found: error
+
+    - name: Upload rdiff
+      uses: actions/upload-artifact@v2
+      with:
+        name: rdiff ${{ matrix.os }} ${{ matrix.build }}
+        path: |
+            ${{github.workspace}}/build/rdiff
+            ${{github.workspace}}/build/rdiff.exe
+        if-no-files-found: error
+

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -38,10 +38,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/upload-artifact@v2
-      with:
-        name: build results ${{ matrix.os }} ${{ matrix.build }}
-        path: ${{github.workspace}}/build
 
     - name: Install Dependencies
       # Unfortunately available Marketplace Actions for this are in a mess, so we do it manually.
@@ -76,3 +72,8 @@ jobs:
       if: ${{matrix.build_docs}}
       run: cmake --build '${{github.workspace}}/build' --target doc
 
+    - name: Upload results
+      uses: actions/upload-artifact@v2
+      with:
+        name: build results ${{ matrix.os }} ${{ matrix.build }}
+        path: ${{github.workspace}}/build

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ html
 latex
 Testing
 *.user
+.cmake
 
 # CMake generated Doxygen files
 CMakeDoxyfile.in


### PR DESCRIPTION
This makes downloadable artifacts out of the whole build tree and install results for every Check run. The build tree is perhaps useful for understanding build failures. The install results gives us compiled binaries and libraries that can be directly installed, which is particularly useful for platforms like Windows.