### PR TITLE
Ignore .cmake directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ html
 latex
 Testing
 *.user
+.cmake
 
 # CMake generated Doxygen files
 CMakeDoxyfile.in


### PR DESCRIPTION
This seems to be produced by some interaction with the LSP:

```
build/.cmake/
└── api
    └── v1
        ├── query
        │   └── client-vscode
        │       └── query.json
        └── reply
            ├── cache-v2-de8827e00eefbe0ab990.json
            ├── codemodel-v2-b00616cea6b8f7146a1d.json
            ├── index-2021-09-07T15-02-32-0670.json
            ├── target-check-Debug-7dda4a54f0e4766a4e86.json
            ├── target-checksum_test-Debug-888c1751d218b338829a.json
            ├── target-clang-tidy-Debug-25483cb1b4dbe3ae1a4c.json
            ├── target-hashtable_test-Debug-45ccd911814c5a8480e0.json
```