### PR TITLE
Update github actions and fix `iwyu` build target.

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,7 +37,7 @@ jobs:
            build: Debug
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install Dependencies
       # Unfortunately available Marketplace Actions for this are in a mess, so we do it manually.
@@ -67,7 +67,7 @@ jobs:
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest -C ${{matrix.build}} --output-on-failure
-      
+
     - name: Build install
       # Build your program with the given configuration.
       run: cmake --install 'build' --config ${{matrix.build}} --prefix 'install'
@@ -77,14 +77,14 @@ jobs:
       run: cmake --build '${{github.workspace}}/build' --target doc
 
     - name: Upload build
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: build results ${{matrix.os}} ${{matrix.build}} ${{matrix.options}}
         path: ${{github.workspace}}/build
         if-no-files-found: error
 
     - name: Upload install
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: install results ${{matrix.os}} ${{matrix.build}} ${{matrix.options}}
         path: ${{github.workspace}}/install

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install Dependencies
       # Unfortunately available Marketplace Actions for this are in a mess, so we do it manually.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,11 +11,9 @@ jobs:
 
     - name: Install Dependencies
       # Unfortunately available Marketplace Actions for this are in a mess, so we do it manually.
-      # Also iwyu is missing a dependency on libclang-common-0-dev, See;
-      # https://bugs.launchpad.net/ubuntu/+source/iwyu/+bug/1769334
       run: |
         sudo apt-get update -y
-        sudo apt-get install -y libpopt-dev libb2-dev clang-tidy libclang-common-9-dev iwyu
+        sudo apt-get install -y libpopt-dev libb2-dev clang-tidy iwyu
 
     - name: Configure CMake
       run: cmake .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,7 +262,7 @@ add_custom_target(clang-tidy
 # iwyu target to check includes for correctness.
 add_custom_target(iwyu
     COMMENT "Check #includes for correctness using iwyu_tool."
-    COMMAND iwyu_tool -p ${CMAKE_CURRENT_BINARY_DIR}
+    COMMAND iwyu_tool -p ${CMAKE_CURRENT_BINARY_DIR} -o clang
     VERBATIM
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,9 +260,10 @@ add_custom_target(clang-tidy
 )
 
 # iwyu target to check includes for correctness.
+# Note we ignore noisy "note:" output and exclude fileutil.c output.
 add_custom_target(iwyu
     COMMENT "Check #includes for correctness using iwyu_tool."
-    COMMAND iwyu_tool -p ${CMAKE_CURRENT_BINARY_DIR} -o clang
+    COMMAND ! iwyu_tool -p ${CMAKE_CURRENT_BINARY_DIR} -o clang | egrep -v "fileutil.c:|note:"
     VERBATIM
 )
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,8 +4,11 @@
 
 NOT RELEASED YET
 
- * Update github actions for checkout and upload-artifact to v3. Update
-   lint.yml action installed packages. (dbaarda
+ * Update github actions and fix `iwyu` build target. Update `checkout` and
+   `upload-artifact` to v3. Update `lint.yml` installed packages for fixed
+   iwyu deps. Fix `iwyu` build target to ignore `fileutil.c` and use neater
+   clang output with noisy "note:" output removed.  Run `make iwyu-fix` to fix
+   includes for `tests/rabinkarp_perf.c`. (dbaarda
    https://github.com/librsync/librsync/pull/243)
 
  * Make delta directly process the input stream if it has enough data. Delta

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,8 @@
 
 NOT RELEASED YET
 
- * Update github actions for checkout and upload-artifact to v3. (dbaarda
+ * Update github actions for checkout and upload-artifact to v3. Update
+   lint.yml action installed packages. (dbaarda
    https://github.com/librsync/librsync/pull/243)
 
  * Make delta directly process the input stream if it has enough data. Delta

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
 
 NOT RELEASED YET
 
+ * Update github actions for checkout and upload-artifact to v3. (dbaarda
+   https://github.com/librsync/librsync/pull/243)
+
  * Make delta directly process the input stream if it has enough data. Delta
    operations will only accumulate data into the internal scoop buffer if the
    input buffer is too small, otherwise it will process the input directly.

--- a/tests/rabinkarp_perf.c
+++ b/tests/rabinkarp_perf.c
@@ -20,7 +20,6 @@
  */
 
 #include <stdio.h>
-#include <stdint.h>
 #include <inttypes.h>
 #include "rabinkarp.h"
 


### PR DESCRIPTION
The old v2 versions of `checkout` and `upload-artifact` github actions now produce errors warning they must be updated. The new versions are v3.

The `iwyu` package has now fixed it's deps and we no longer need to explicitly install `libclang-common-9-dev` which doesn't exist any more.

The `iwyu` build target should ignore `fileutil.c`, and use neater clang output with noisy "note:" output removed.

Run `make iwyu-fix` to fix includes for `tests/rabinkarp_perf.c`.