### PR TITLE
Fix #244 Add win32 install artifact to release instructions.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -266,19 +266,27 @@ Fixes or improvements in pull requests are welcome.  Please:
 
 If you are making a new tarball release of librsync, follow this checklist:
 
-* NEWS.md - make sure the top "Changes in X.Y.Z" is correct, and the date is
-  correct. Make sure the changes since the last release are documented.
+* Make a "Release vx.x.x" pull request containing updates ready for the
+  release including;
 
-* TODO.md - check if anything needs to be removed or updated.
+   * Review the changes included and decide if the release should be a major
+     (non-backwards compatible change), minor (backwards compatible change),
+     or micro (bugfix only change) version number change to get the new
+     "X.Y.Z" version number.
 
-* `CMakeLists.txt` - version is correct.
+   * NEWS.md - make sure the top "Changes in X.Y.Z" is correct, and the date
+     is correct. Make sure the changes since the last release are documented.
 
-* `librsync.spec` - make sure version and URL are right.
+   * TODO.md - check if anything needs to be removed or updated.
 
-* Run `make all doc check` in a clean checkout of the release tag. Also check
-  the GitHub Actions [check and lint
+   * `CMakeLists.txt` - version is correct.
+
+   * `librsync.spec` - make sure version and URL are right.
+
+* Run `make all doc check` in a clean checkout of the release pull request
+  branch. Also check the GitHub Actions [check and lint
   status](https://github.com/librsync/librsync/actions) of the last commit on
-  github.
+  github. If it all looks good merge the release pull request on github.
 
 * Draft a new release on github, typing in the release details including an
   overview, included changes, and known issues. The overview should give an
@@ -287,6 +295,25 @@ If you are making a new tarball release of librsync, follow this checklist:
   NEWS.md for the release. It's probably easiest to copy and edit the previous
   release.
 
-* After creating the release, download the tar.gz version, edit the release,
-  and re-upload it. This ensures that the release includes a stable tarball
-  (See https://github.com/librsync/librsync/issues/146 for details).
+* After creating the release, download the `Source code (tar.gz)` release
+  asset. Go to "Actions", find the workflow run for the "Check" corresponding
+  to the merge of the release pull request, and download the `install results
+  windows-latest Release` artifact renamed to 'librsync-win64-x.x.x.zip`. Edit
+  the release, and upload the source code and windows artifacts. This ensures
+  that the release includes a stable tarball (See
+  https://github.com/librsync/librsync/issues/146 for details) and win64
+  install.
+
+* Run `make doc` on a clean checkout of the new release tag and `cp -av doc/*`
+  into a `rm -Rf *` emptied checkout of librsync.github.io and check it in.
+  This ensures it includes deletes of obsolete files as well as new and
+  updated files. Push this to update the online docs.
+
+* Create and merge a "Prepare vX.Y.Z+1." pull request containing updates to
+  prepare for the changes in the next release including;
+
+   * Bump the minor version in `CMakeLists.txt`.
+
+   * Add a `NOT RELEASED YET` version entry in `NEWS.md`
+
+   * Bump the minor version and add a `%changelog` entry in `librsync.spec`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -298,7 +298,7 @@ If you are making a new tarball release of librsync, follow this checklist:
 * After creating the release, download the `Source code (tar.gz)` release
   asset. Go to "Actions", find the workflow run for the "Check" corresponding
   to the merge of the release pull request, and download the `install results
-  windows-latest Release` artifact renamed to 'librsync-win64-x.x.x.zip`. Edit
+  windows-latest Release` artifact renamed to `librsync-win64-X.Y.Z.zip`. Edit
   the release, and upload the source code and windows artifacts. This ensures
   that the release includes a stable tarball (See
   https://github.com/librsync/librsync/issues/146 for details) and win64

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@ NOT RELEASED YET
  * Add windows build to stable release. Updated CONTRIBUTING.md release
    instructions to be clearer and include instructions on how to upload the
    win64 install artifact from the github "Check" action. (dbaarda,
-   https://github.com/librsync/librsync/pull/???)
+   https://github.com/librsync/librsync/pull/245)
 
  * Update github actions and fix `iwyu` build target. Update `checkout` and
    `upload-artifact` to v3. Update `lint.yml` installed packages for fixed

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,12 +4,20 @@
 
 NOT RELEASED YET
 
+ * Add windows build to stable release. Updated CONTRIBUTING.md release
+   instructions to be clearer and include instructions on how to upload the
+   win64 install artifact from the github "Check" action. (dbaarda,
+   https://github.com/librsync/librsync/pull/???)
+
  * Update github actions and fix `iwyu` build target. Update `checkout` and
    `upload-artifact` to v3. Update `lint.yml` installed packages for fixed
    iwyu deps. Fix `iwyu` build target to ignore `fileutil.c` and use neater
    clang output with noisy "note:" output removed.  Run `make iwyu-fix` to fix
    includes for `tests/rabinkarp_perf.c`. (dbaarda
    https://github.com/librsync/librsync/pull/243)
+
+ * Add missing word to README.md. (AvdN,
+   https://github.com/librsync/librsync/pull/237)
 
  * Make delta directly process the input stream if it has enough data. Delta
    operations will only accumulate data into the internal scoop buffer if the
@@ -19,6 +27,10 @@ NOT RELEASED YET
 
  * Add .gitignore for `.cmake` created by LSP on Windows. (sourcefrog,
    https://github.com/librsync/librsync/pull/232)
+
+ * Upload build and install artifacts from Github actions. This means we get
+   downloadable build and install artifacts for all platforms from the "Check"
+   action. (sourcefrog, https://github.com/librsync/librsync/pull/231)
 
  * Improve documentation so that Doxygen generates more complete documentation
    with diagrams, renders better, and is more navigable as markdown docs on

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,9 +4,9 @@
 
 NOT RELEASED YET
 
- * Add windows build to stable release. Updated CONTRIBUTING.md release
-   instructions to be clearer and include instructions on how to upload the
-   win64 install artifact from the github "Check" action. (dbaarda,
+ * Fix #244 Add windows build to stable release. Updated CONTRIBUTING.md
+   release instructions to be clearer and include instructions on how to
+   upload the win64 install artifact from the github "Check" action. (dbaarda,
    https://github.com/librsync/librsync/pull/245)
 
  * Update github actions and fix `iwyu` build target. Update `checkout` and


### PR DESCRIPTION
This ensures we have a compiled win64 release artifact with each release. Also updated NEWS.md to include all pull requests since the last release.