### PR TITLE
Fix #248 by putting `#include "config.h"` in most src/*.c files.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,18 +260,17 @@ add_custom_target(clang-tidy
 )
 
 # iwyu target to check includes for correctness.
-# Note we ignore noisy "note:" output and exclude fileutil.c output.
+# Note we ignore noisy "note:" output.
 add_custom_target(iwyu
     COMMENT "Check #includes for correctness using iwyu_tool."
-    COMMAND ! iwyu_tool -p ${CMAKE_CURRENT_BINARY_DIR} -o clang | egrep -v "fileutil.c:|note:"
+    COMMAND ! iwyu_tool -p ${CMAKE_CURRENT_BINARY_DIR} -o clang | egrep -v "note:"
     VERBATIM
 )
 
 # iwyu-fix target to fix includes for correctness.
-# Note fileutil.c gets mangled by this and is excluded.
 add_custom_target(iwyu-fix
     COMMENT "Fix #includes for correctness using iwyu_tool and fix_include."
-    COMMAND iwyu_tool -p ${CMAKE_CURRENT_BINARY_DIR} | fix_include --noblank_lines --ignore_re=fileutil.c
+    COMMAND iwyu_tool -p ${CMAKE_CURRENT_BINARY_DIR} | fix_include --noblank_lines
     VERBATIM
 )
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,12 +4,13 @@
 
 NOT RELEASED YET
 
- * Fix #248 by putting `#include "config.h"` in most `src/*.c` files. Add `/*
-   IWYU pragma: keep */` to includes in `src/fileutil.c` that are needed on
-   some platforms but not others so we can remove the special exemptions to
-   skip this file for the iwyu and iwyu-fix targets in `CMakeLists.txt`. Also
-   add some typecasts to `rollsum.[ch]` and `patch.c` to silence warnings on
-   Windows. (dbaarda, https://github.com/librsync/librsync/pull/249)
+ * Fix #248 by putting `#include "config.h"` with `/* IWYU pragma: keep */` in
+   most `src/*.c` files. Add `/* IWYU pragma: keep */` to includes in
+   `src/fileutil.c` that are needed on some platforms but not others so we can
+   remove the special exemptions to skip this file for the iwyu and iwyu-fix
+   targets in `CMakeLists.txt`. Also add some typecasts to `rollsum.[ch]` and
+   `patch.c` to silence warnings on Windows. (dbaarda,
+   https://github.com/librsync/librsync/pull/249)
 
 ## librsync 2.3.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,12 @@
 
 NOT RELEASED YET
 
+ * Fix #248 by putting #include "config.h" in most src/*.c files. Add `/* IWYU
+   pragma: keep */` to includes in `src/fileutil.c` that are needed on some
+   platforms but not others so we can remove the special exemptions to skip
+   this file for the iwyu and iwyu-fix targets in CMakeLists.txt. (dbaarda,
+   https://github.com/librsync/librsync/pull/249)
+
 ## librsync 2.3.3
 
 Released 2023-02-16
@@ -17,7 +23,7 @@ Released 2023-02-16
    `upload-artifact` to v3. Update `lint.yml` installed packages for fixed
    iwyu deps. Fix `iwyu` build target to ignore `fileutil.c` and use neater
    clang output with noisy "note:" output removed.  Run `make iwyu-fix` to fix
-   includes for `tests/rabinkarp_perf.c`. (dbaarda
+   includes for `tests/rabinkarp_perf.c`. (dbaarda,
    https://github.com/librsync/librsync/pull/243)
 
  * Add missing word to README.md. (AvdN,

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,11 +4,12 @@
 
 NOT RELEASED YET
 
- * Fix #248 by putting #include "config.h" in most src/*.c files. Add `/* IWYU
-   pragma: keep */` to includes in `src/fileutil.c` that are needed on some
-   platforms but not others so we can remove the special exemptions to skip
-   this file for the iwyu and iwyu-fix targets in CMakeLists.txt. (dbaarda,
-   https://github.com/librsync/librsync/pull/249)
+ * Fix #248 by putting `#include "config.h"` in most `src/*.c` files. Add `/*
+   IWYU pragma: keep */` to includes in `src/fileutil.c` that are needed on
+   some platforms but not others so we can remove the special exemptions to
+   skip this file for the iwyu and iwyu-fix targets in `CMakeLists.txt`. Also
+   add some typecasts to `rollsum.[ch]` and `patch.c` to silence warnings on
+   Windows. (dbaarda, https://github.com/librsync/librsync/pull/249)
 
 ## librsync 2.3.3
 

--- a/src/base64.c
+++ b/src/base64.c
@@ -19,6 +19,7 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
+#include "config.h"             /* IWYU pragma: keep */
 #include <stdlib.h>
 #include <string.h>
 #include "librsync.h"

--- a/src/buf.c
+++ b/src/buf.c
@@ -23,6 +23,7 @@
                                | Pick a window, Jimmy, you're leaving.
                                */
 
+#include "config.h"             /* IWYU pragma: keep */
 #include <assert.h>
 #include <stdlib.h>
 #include <errno.h>

--- a/src/checksum.c
+++ b/src/checksum.c
@@ -21,6 +21,7 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
+#include "config.h"             /* IWYU pragma: keep */
 #include <stdint.h>
 #include "checksum.h"
 #include "blake2.h"

--- a/src/command.c
+++ b/src/command.c
@@ -19,6 +19,7 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
+#include "config.h"             /* IWYU pragma: keep */
 #include <stddef.h>
 #include "command.h"
 

--- a/src/delta.c
+++ b/src/delta.c
@@ -88,6 +88,7 @@
  * and scan_pos adjusted. Everything gets complicated because the tube can
  * block. When the tube is blocked, no data can be processed. */
 
+#include "config.h"             /* IWYU pragma: keep */
 #include <assert.h>
 #include <stdlib.h>
 #include "librsync.h"

--- a/src/emit.c
+++ b/src/emit.c
@@ -19,6 +19,7 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
+#include "config.h"             /* IWYU pragma: keep */
 #include <assert.h>
 #include "librsync.h"
 #include "emit.h"

--- a/src/fileutil.c
+++ b/src/fileutil.c
@@ -20,28 +20,31 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-#include "config.h"
+/* This provides a compatiblity layer for file operations on different
+   platforms. We need to tell IWYU to keep some headers because they are
+   required on some platforms but not others. */
+#include "config.h"             /* IWYU pragma: keep */
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
 #ifdef HAVE_UNISTD_H
-#  include <unistd.h>
+#  include <unistd.h>           /* IWYU pragma: keep */
 #endif
 #ifdef HAVE_FCNTL_H
-#  include <fcntl.h>
+#  include <fcntl.h>            /* IWYU pragma: keep */
 #endif
 #ifdef HAVE_SYS_TYPES_H
-#  include <sys/types.h>
+#  include <sys/types.h>        /* IWYU pragma: keep */
 #endif
 #ifdef HAVE_SYS_FILE_H
-#  include <sys/file.h>
+#  include <sys/file.h>         /* IWYU pragma: keep */
 #endif
 #ifdef HAVE_SYS_STAT_H
-#  include <sys/stat.h>
+#  include <sys/stat.h>         /* IWYU pragma: keep */
 #endif
 #ifdef HAVE_IO_H
-#  include <io.h>
+#  include <io.h>               /* IWYU pragma: keep */
 #endif
 #include "librsync.h"
 #include "trace.h"

--- a/src/hex.c
+++ b/src/hex.c
@@ -17,6 +17,7 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
+#include "config.h"             /* IWYU pragma: keep */
 #include "librsync.h"
 
 void rs_hexify(char *to_buf, void const *from, int from_len)

--- a/src/isprefix.c
+++ b/src/isprefix.c
@@ -18,6 +18,7 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
+#include "config.h"             /* IWYU pragma: keep */
 #include "isprefix.h"
 
 int isprefix(char const *tip, char const *iceberg)

--- a/src/job.c
+++ b/src/job.c
@@ -25,6 +25,7 @@
                                | sheltering.
                                */
 
+#include "config.h"             /* IWYU pragma: keep */
 #include <assert.h>
 #include <stdlib.h>
 #include <time.h>

--- a/src/mdfour.c
+++ b/src/mdfour.c
@@ -21,6 +21,7 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
+#include "config.h"             /* IWYU pragma: keep */
 #include <stdint.h>
 #include <string.h>
 #include "librsync.h"

--- a/src/mksum.c
+++ b/src/mksum.c
@@ -27,6 +27,7 @@
  * whatever data is available. When a whole block has arrived, or we've reached
  * the end of the file, we write the checksum out. */
 
+#include "config.h"             /* IWYU pragma: keep */
 #include <stdlib.h>
 #include "librsync.h"
 #include "job.h"

--- a/src/msg.c
+++ b/src/msg.c
@@ -40,6 +40,7 @@
  * description of a job, including only the fields relevant to the current
  * encoding function. */
 
+#include "config.h"             /* IWYU pragma: keep */
 #include "librsync.h"
 
 char const *rs_strerror(rs_result r)

--- a/src/netint.c
+++ b/src/netint.c
@@ -27,6 +27,7 @@
                              |        -- Sun Microsystems
                              */
 
+#include "config.h"             /* IWYU pragma: keep */
 #include <assert.h>
 #include "librsync.h"
 #include "netint.h"

--- a/src/patch.c
+++ b/src/patch.c
@@ -167,7 +167,7 @@ static rs_result rs_patch_s_copying(rs_job_t *job)
     if (!len)
         return RS_BLOCKED;
     /* Adjust request to min of amount requested and space available. */
-    if (len < req)
+    if ((rs_long_t)len < req)
         req = (rs_long_t)len;
     rs_trace("copy " FMT_LONG " bytes from basis at offset " FMT_LONG "", req,
              job->basis_pos);
@@ -181,7 +181,7 @@ static rs_result rs_patch_s_copying(rs_job_t *job)
     /* Actual copied length cannot be greater than requested length. */
     assert(len <= req);
     /* Backwards-compatible defensively handle this for NDEBUG builds. */
-    if (len > req) {
+    if ((rs_long_t)len > req) {
         rs_warn("copy_cb() returned more than the requested length");
         len = (size_t)req;
     }

--- a/src/patch.c
+++ b/src/patch.c
@@ -26,6 +26,7 @@
 /** \file patch.c
  * Apply a delta to an old file to generate a new file. */
 
+#include "config.h"             /* IWYU pragma: keep */
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/prototab.c
+++ b/src/prototab.c
@@ -20,6 +20,7 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
+#include "config.h"             /* IWYU pragma: keep */
 #include "command.h"
 #include "prototab.h"
 

--- a/src/rabinkarp.c
+++ b/src/rabinkarp.c
@@ -18,6 +18,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
+#include "config.h"             /* IWYU pragma: keep */
 #include "rabinkarp.h"
 
 /* Constant for RABINKARP_MULT^2. */

--- a/src/rdiff.c
+++ b/src/rdiff.c
@@ -43,12 +43,12 @@
  *
  * \todo Add an option for delta to check whether the files are identical. */
 
+#include "config.h"             /* IWYU pragma: keep */
 #include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>
 #include <popt.h>
 #include <stdio.h>
-#include "config.h"
 #include "librsync.h"
 #include "isprefix.h"
 

--- a/src/readsums.c
+++ b/src/readsums.c
@@ -23,6 +23,7 @@
 /** \file readsums.c
  * Load signatures from a file. */
 
+#include "config.h"             /* IWYU pragma: keep */
 #include "librsync.h"
 #include "job.h"
 #include "sumset.h"

--- a/src/rollsum.c
+++ b/src/rollsum.c
@@ -47,8 +47,8 @@ void RollsumUpdate(Rollsum *sum, const unsigned char *buf, size_t len)
         n--;
     }
     /* Increment s1 and s2 by the amounts added by the char offset. */
-    s1 += len * ROLLSUM_CHAR_OFFSET;
-    s2 += ((len * (len + 1)) / 2) * ROLLSUM_CHAR_OFFSET;
+    s1 += (uint_fast16_t)len * ROLLSUM_CHAR_OFFSET;
+    s2 += (uint_fast16_t)((len * (len + 1)) / 2) * ROLLSUM_CHAR_OFFSET;
     sum->count += len;          /* Increment sum count. */
     sum->s1 = s1;
     sum->s2 = s2;

--- a/src/rollsum.c
+++ b/src/rollsum.c
@@ -19,6 +19,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
+#include "config.h"             /* IWYU pragma: keep */
 #include "rollsum.h"
 
 #define DO1(buf,i)  {s1 += buf[i]; s2 += s1;}

--- a/src/rollsum.h
+++ b/src/rollsum.h
@@ -52,7 +52,7 @@ static inline void RollsumRotate(Rollsum *sum, unsigned char out,
                                  unsigned char in)
 {
     sum->s1 += in - out;
-    sum->s2 += sum->s1 - sum->count * (out + ROLLSUM_CHAR_OFFSET);
+    sum->s2 += sum->s1 - (uint_fast16_t)sum->count * (out + ROLLSUM_CHAR_OFFSET);
 }
 
 static inline void RollsumRollin(Rollsum *sum, unsigned char in)
@@ -65,7 +65,7 @@ static inline void RollsumRollin(Rollsum *sum, unsigned char in)
 static inline void RollsumRollout(Rollsum *sum, unsigned char out)
 {
     sum->s1 -= out + ROLLSUM_CHAR_OFFSET;
-    sum->s2 -= sum->count * (out + ROLLSUM_CHAR_OFFSET);
+    sum->s2 -= (uint_fast16_t)sum->count * (out + ROLLSUM_CHAR_OFFSET);
     sum->count--;
 }
 

--- a/src/scoop.c
+++ b/src/scoop.c
@@ -52,6 +52,7 @@
  * would be kind of nice to not do any memory allocation after startup, as
  * bzlib does this. */
 
+#include "config.h"             /* IWYU pragma: keep */
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/stats.c
+++ b/src/stats.c
@@ -23,6 +23,7 @@
  * \todo Other things to show in statistics: number of input and output bytes,
  * number of times we blocked waiting for input or output, number of blocks. */
 
+#include "config.h"             /* IWYU pragma: keep */
 #include <stdio.h>
 #include "librsync.h"
 #include "trace.h"

--- a/src/sumset.c
+++ b/src/sumset.c
@@ -20,6 +20,7 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
+#include "config.h"             /* IWYU pragma: keep */
 #include <stdlib.h>
 #include <string.h>
 #include "librsync.h"

--- a/src/trace.c
+++ b/src/trace.c
@@ -26,9 +26,9 @@
                                       | There are lumps in it.
                                       */
 
+#include "config.h"             /* IWYU pragma: keep */
 #include <stdio.h>
 #include <stdarg.h>
-#include "config.h"
 #include "librsync.h"
 #include "trace.h"
 #include "util.h"

--- a/src/tube.c
+++ b/src/tube.c
@@ -51,6 +51,7 @@
  * in that case we might need to copy into some temporary buffer space, and
  * then back out again later. */
 
+#include "config.h"             /* IWYU pragma: keep */
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/util.c
+++ b/src/util.c
@@ -23,6 +23,7 @@
                                  | On heroin, I have all the answers.
                                  */
 
+#include "config.h"             /* IWYU pragma: keep */
 #include <stdlib.h>
 #include <string.h>
 #include "librsync.h"

--- a/src/version.c
+++ b/src/version.c
@@ -19,7 +19,7 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-#include "config.h"
+#include "config.h"             /* IWYU pragma: keep */
 #include "librsync_export.h"
 
 LIBRSYNC_EXPORT char const rs_librsync_version[] = PACKAGE " " VERSION;

--- a/src/whole.c
+++ b/src/whole.c
@@ -27,6 +27,7 @@
                                |        -- Alan Perlis
                                */
 
+#include "config.h"             /* IWYU pragma: keep */
 #include <stdio.h>
 #include <string.h>
 #include "librsync.h"


### PR DESCRIPTION
The iwyu tool doesn't handle `config.h` files well, and these includes were incorrectly removed, which breaks things on some platforms. Add them back to most `src/*.c` files with `/* IWYU pragma: keep */` to make iwyu ignore them. We skip `src/hashtable.c` because it is a standalone utilty that is platform independent.

Also add `/* IWYU pragma: keep */` to includes in `src/fileutil.c` that are needed on some platforms but not others. This means we can remove the special exemptions to skip this file for the `iwyu` and `iwyu-fix` targets in `CMakeLists.txt`.