### PR TITLE
Release v2.3.4.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -304,7 +304,7 @@ If you are making a new tarball release of librsync, follow this checklist:
   https://github.com/librsync/librsync/issues/146 for details) and win64
   install.
 
-* Run `make doc` on a clean checkout of the new release tag and `cp -av doc/*`
+* Run `make doc` on a clean checkout of the new release tag and `cp -av html/*`
   into a `rm -Rf *` emptied checkout of librsync.github.io and check it in.
   This ensures it includes deletes of obsolete files as well as new and
   updated files. Push this to update the online docs.

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## librsync 2.3.4
 
-NOT RELEASED YET
+Released 2023-02-19
 
  * Fix #248 by putting `#include "config.h"` with `/* IWYU pragma: keep */` in
    most `src/*.c` files. Add `/* IWYU pragma: keep */` to includes in

--- a/librsync.spec
+++ b/librsync.spec
@@ -72,8 +72,8 @@ rm -rf $RPM_BUILD_ROOT
 %{_includedir}/%{name}*
 
 %changelog
-* Thu Feb 16 2023 Donovan Baarda <abo@minkirri.apana.org.au>
-- Prepare SPEC file for librsync 2.3.4
+* Sun Feb 19 2023 Donovan Baarda <abo@minkirri.apana.org.au>
+- Updated SPEC file for librsync 2.3.4
 * Thu Feb 16 2023 Donovan Baarda <abo@minkirri.apana.org.au>
 - Updated SPEC file for librsync 2.3.3
 * Sat Apr 10 2021 Donovan Baarda <abo@minkirri.apana.org.au>


### PR DESCRIPTION
Update everything necessary in preparation for release of v2.3.2. Note CMakeLists.txt and TODO.md are already up to date. Also correct `CONTRIBUTING.md` release instructions for the right `html` path for doxygen docs.