### PR TITLE
Update to upload-artifact@v4

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -77,14 +77,14 @@ jobs:
       run: cmake --build '${{github.workspace}}/build' --target doc
 
     - name: Upload build
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: build results ${{matrix.os}} ${{matrix.build}} ${{matrix.options}}
         path: ${{github.workspace}}/build
         if-no-files-found: error
 
     - name: Upload install
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: install results ${{matrix.os}} ${{matrix.build}} ${{matrix.options}}
         path: ${{github.workspace}}/install


### PR DESCRIPTION
The current v3 is failing in https://github.com/librsync/librsync/actions/runs/14822488795/job/41611359533#step:1:42 and apparently the update should fix this https://github.com/orgs/community/discussions/152695. I don't think we're relying on any behaviors that will break with the update. In particular, [v4 requires that the file names be unique](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes) but we seem to already do that by including matrix parameters.

There are IWYU failures that seem unrelated (#262).