### PR TITLE
Disable IWYU in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,5 +21,7 @@ jobs:
     - name: clang-tidy
       run: cmake --build . --target clang-tidy
 
-    - name: iwyu
-      run: cmake --build . --target iwyu
+    # We don't run IWYU from CI because it's oriented to codebases with no recursive includes,
+    # but librsync does have recursive includes.
+    # - name: iwyu
+    #   run: cmake --build . --target iwyu

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,6 +261,10 @@ add_custom_target(clang-tidy
 
 # iwyu target to check includes for correctness.
 # Note we ignore noisy "note:" output.
+#
+# Note that iwyu is oriented to codebases with no recursive includes,
+# but librsync does currently have recursive includes; this may give warnings
+# for some files that are not practical problems.
 add_custom_target(iwyu
     COMMENT "Check #includes for correctness using iwyu_tool."
     COMMAND ! iwyu_tool -p ${CMAKE_CURRENT_BINARY_DIR} -o clang | egrep -v "note:"


### PR DESCRIPTION
Fixes #262

I'm not sure avoiding transient includes is really a worthwhile migration here, so this just disables the check in CI.

I could also see an argument that we should either:
1. Remove it altogether
2. Refactor the headers so that `librsync.h` pulls in everything in the public API and underneath that there are no recursive includes
3. (Some other refactor?)